### PR TITLE
chore: remove Trivy vulnerability scanner from build workflow

### DIFF
--- a/.github/workflows/build-container-image.yaml
+++ b/.github/workflows/build-container-image.yaml
@@ -80,18 +80,3 @@ jobs:
           subject-name: ghcr.io/${{ github.repository }}
           subject-digest: ${{ steps.docker_build.outputs.digest }}
           push-to-registry: true
-
-      - name: Run Trivy vulnerability scanner
-        if: ${{ github.event_name == 'push' }}
-        uses: aquasecurity/trivy-action@master
-        with:
-          image-ref: ghcr.io/${{ github.repository }}:${{ steps.meta.outputs.version }}
-          format: 'sarif'
-          output: 'trivy-results.sarif'
-          severity: 'CRITICAL,HIGH'
-
-      - name: Upload Trivy scan results to GitHub Security tab
-        if: ${{ github.event_name == 'push' }}
-        uses: github/codeql-action/upload-sarif@v3
-        with:
-          sarif_file: 'trivy-results.sarif'


### PR DESCRIPTION
## Summary

This PR removes the Trivy vulnerability scanner from the container image build workflow.

## Changes

- Remove Trivy vulnerability scanner step from the build workflow
- Remove upload of Trivy scan results to GitHub Security tab

## Rationale

The Trivy scanner steps are being removed to simplify the build workflow and reduce dependencies on external actions.

## Test Plan

- [x] Verify container image build workflow completes successfully without Trivy scanner
- [x] Confirm that container images are still built and pushed correctly