### PR TITLE
fix: refine push condition for Docker image build

### DIFF
--- a/.github/workflows/build-container-image.yaml
+++ b/.github/workflows/build-container-image.yaml
@@ -66,7 +66,7 @@ jobs:
           platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          push: ${{ github.event_name == 'push' }}
+          push: ${{ github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')) }}
           provenance: mode=max
           cache-from: type=gha
           cache-to: type=gha,mode=max


### PR DESCRIPTION
## Summary
- Refine Docker image push condition to only push on main branch or tag pushes

## Test plan
- [ ] Verify workflow runs successfully in GitHub Actions
- [ ] Confirm images are built and pushed on pushes to main branch
- [ ] Confirm images are built and pushed on tag pushes (v*)
- [ ] Confirm images are only built (not pushed) on pushes to other branches