### PR TITLE
implement RBAC

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,5 @@ go.work
 **/public/**
 
 **/example/**
+
+content/

--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ Create a YAML file named ``gic.config.yaml`` and write your credentials.
 github:
   username: '<YOUR_GITHUB_USERNAME>'
   repository: '<YOUR_GITHUB_REPOSITORY>'
+  allowed_authors:
+    - '<ALLOWED_AUTHOR_FOR_ISSUE>'
 
 hugo:
   filename:
@@ -115,3 +117,23 @@ jobs:
 Congratulations.
 
 Your Hugo site will automatically deployed when a Issue is closed or reopened.
+
+## Usage
+### Generate articles
+
+```bash
+$ github-issue-cms generate --token="YOUR_GITHUB_TOKEN"
+```
+
+### Set allowed authors
+You can set allowed authors in the `gic.config.yaml` file. This is useful to filter issues by author.
+For example, if you want to allow only specific users, in this example, `rokuosan`, to create articles, you can set it like this:
+```yaml
+github:
+  username: '<YOUR_GITHUB_USERNAME>'
+  repository: '<YOUR_GITHUB_REPOSITORY>'
+  allowed_authors:
+    - 'rokuosan'
+```
+Now, only issues created by `rokuosan` will be converted to articles.
+In default, all issues are allowed.

--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -36,7 +36,9 @@ The articles will be saved in the "content" directory.`,
 		slog.Info("Converting articles...")
 		for _, issue := range issues {
 			article := c.IssueToArticle(issue)
-			article.Export(conf)
+			if article != nil {
+				article.Export(conf)
+			}
 		}
 
 		slog.Info("Complete")

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -20,6 +20,9 @@ var initCmd = &cobra.Command{
 		if repository := cmd.Flag("repository").Value.String(); repository != "<YOUR_REPOSITORY>" {
 			viper.Set("github.repository", repository)
 		}
+		if allowedAuthors := cmd.Flag("allowed_authors").Value.String(); allowedAuthors != "<YOUR_ALLOWED_AUTHORS>" {
+			viper.Set("github.allowed_authors", allowedAuthors)
+		}
 
 		if err := viper.WriteConfig(); err != nil {
 			panic(err)
@@ -32,4 +35,5 @@ func init() {
 
 	initCmd.Flags().StringP("username", "u", "<YOUR_USERNAME>", "GitHub username")
 	initCmd.Flags().StringP("repository", "r", "<YOUR_REPOSITORY>", "GitHub repository")
+	initCmd.Flags().StringP("allowed_authors", "a", "<YOUR_ALLOWED_AUTHORS>", "Comma-separated list of allowed authors")
 }

--- a/gic.config.yaml
+++ b/gic.config.yaml
@@ -1,6 +1,8 @@
 github:
-  username: 'rokuosan'
-  repository: 'github-issue-cms'
+  username: 'Retasusan'
+  repository: 'github-issue-cms-articles'
+  allowed_authors:
+    - 'Retasusan'
 
 hugo:
   filename:

--- a/gic.config.yaml
+++ b/gic.config.yaml
@@ -1,8 +1,8 @@
 github:
-  username: 'Retasusan'
-  repository: 'github-issue-cms-articles'
+  username: 'rokuosan'
+  repository: 'github-issue-cms'
   allowed_authors:
-    - 'Retasusan'
+    - 'rokuosan'
 
 hugo:
   filename:

--- a/pkg/config/type.go
+++ b/pkg/config/type.go
@@ -9,8 +9,9 @@ type Config struct {
 }
 
 type GitHubConfig struct {
-	Username   string `yaml:"username"`
-	Repository string `yaml:"repository"`
+	Username         string `yaml:"username"`
+	Repository       string `yaml:"repository"`
+	AllowedAuthors []string `yaml:"allowed_authors" mapstructure:"allowed_authors"`
 }
 
 type HugoConfig struct {

--- a/pkg/converter/converter.go
+++ b/pkg/converter/converter.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"path/filepath"
 	"regexp"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -143,6 +144,19 @@ func (c *converterImpl) IssueToArticle(issue *github.Issue) *Article {
 	if issue.IsPullRequest() {
 		return nil
 	}
+
+	if c.config.GitHub != nil && len(c.config.GitHub.AllowedAuthors) > 0 {
+		author := ""
+		if issue.User != nil {
+			author = issue.GetUser().GetLogin()
+		}
+		allowed := slices.Contains(c.config.GitHub.AllowedAuthors, author)
+		if !allowed {
+			slog.Debug(fmt.Sprintf("Author '%s' is not allowed. Skipping issue #%d", author, issue.GetNumber()))
+			return nil
+		}
+	}
+
 	num := strconv.Itoa(issue.GetNumber())
 	slog.Debug("Converting #" + num + "...")
 


### PR DESCRIPTION
## implement RBAC
- [issue](https://github.com/rokuosan/github-issue-cms/issues/23) 

## what I've done
- add `content/` to .gitignore
   - this may not good
- add conditional branch to `IssueToArticle` function
   - this may not good too
- add `allowe_author` param to `init.go`, `--init` command
- change type definition of yaml
- add test for `IssueToArticle`

## what I want to ask
- As one of the developer, it is a hassle to check every time whether `gic.config.yaml` or the `content` directory has been pushed. Is it fine to add `content` or `gic.config.yaml` to `.gitignore` file?
- In this implementation, specificaly in `cmd/generate.go` and  `pkg/converter/article.go` file's below implements, all nil will treated as error. But in the RBAC, I want to ignore the non allowed user. How can I implement this ? Please give me some oracle...
```generate.go
for _, issue := range issues {
  article := c.IssueToArticle(issue)
  article.Export(conf)
}
```
```article.go
func (a *Article) Export(conf config.Config) {
  // Build String
  text, err := a.Transform()
  if err != nil {
  panic(err)
}
```