### PR TITLE
Pin documented install version to v0.6.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Issues are treated as articles.
 ### 1. Install this application
 
 ```bash
-$ go install github.com/rokuosan/github-issue-cms@latest
+$ go install github.com/rokuosan/github-issue-cms@v0.6.1
 ```
 
 ### 2. Create Config file
@@ -101,7 +101,7 @@ jobs:
         go-version: '1.21.4'
 
     - name: Install
-      run: go install github.com/rokuosan/github-issue-cms@latest
+      run: go install github.com/rokuosan/github-issue-cms@v0.6.1
 
     - name: Generate
       run: github-issue-cms generate --token=${{ secrets.GH_TOKEN }}

--- a/docs/content/quickstart.ja.md
+++ b/docs/content/quickstart.ja.md
@@ -23,7 +23,7 @@ weight: 1
 以下のコマンドを実行します。
 
 ```shell
-$ go install github.com/rokuosan/github-issue-cms@latest
+$ go install github.com/rokuosan/github-issue-cms@v0.6.1
 ```
 
 ### 2. コンフィグの作成

--- a/docs/content/quickstart.md
+++ b/docs/content/quickstart.md
@@ -23,7 +23,7 @@ The following are required. Please prepare them in advance.
 Run the following command:
 
 ```shell
-$ go install github.com/rokuosan/github-issue-cms@latest
+$ go install github.com/rokuosan/github-issue-cms@v0.6.1
 ```
 
 ### 2. Create configuration file


### PR DESCRIPTION
## Summary
- replace `@latest` with `@v0.6.1` in installation examples
- update both README and quickstart docs to use the explicit version
- keep the documented setup aligned with the intended release

## Testing
- not run (documentation-only change)