### PR TITLE
Update Go toolchain and align CI/Docker configuration

### DIFF
--- a/.github/workflows/ci-golang.yaml
+++ b/.github/workflows/ci-golang.yaml
@@ -16,11 +16,11 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.24'
+          go-version-file: go.mod
       - name: golangci-lint
         uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8.0.0
         with:
-          version: v2.3.0
+          version: v2.11.4
 
   test:
     name: test
@@ -29,6 +29,6 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.24'
+          go-version-file: go.mod
       - name: test
         run: go test -v ./...

--- a/.github/workflows/deploy-pages.yaml
+++ b/.github/workflows/deploy-pages.yaml
@@ -43,7 +43,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.24'
+          go-version-file: go.mod
       - name: Setup Pages
         id: pages
         uses: actions/configure-pages@v5

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v4
       with:
-        go-version: '1.21.4'
+        go-version: '1.25.0'
 
     - name: Install
       run: go install github.com/rokuosan/github-issue-cms@v0.6.1

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.2-alpine3.20 AS builder
+FROM golang:1.26.2-alpine3.23 AS builder
 
 RUN apk add --no-cache git gcc musl-dev
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24-alpine3.20 AS builder
+FROM golang:1.26.2-alpine3.20 AS builder
 
 RUN apk add --no-cache git gcc musl-dev
 

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/rokuosan/github-issue-cms
 
 go 1.25.0
 
-toolchain go1.26
+toolchain go1.26.2
 
 require (
 	github.com/google/go-cmp v0.7.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/rokuosan/github-issue-cms
 
-go 1.24
+go 1.25.0
+
+toolchain go1.26
 
 require (
 	github.com/google/go-cmp v0.7.0
@@ -8,7 +10,6 @@ require (
 	github.com/spf13/cobra v1.9.1
 	github.com/spf13/viper v1.20.1
 	github.com/stretchr/testify v1.10.0
-	go.uber.org/mock v0.5.2
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -45,8 +45,6 @@ github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOf
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/subosito/gotenv v1.6.0 h1:9NlTDc1FTs4qu0DDq7AEtTPNw6SVm7uBMsUCUjABIf8=
 github.com/subosito/gotenv v1.6.0/go.mod h1:Dk4QP5c2W3ibzajGcXpNraDfq2IrhjMIvMSWPKKo0FU=
-go.uber.org/mock v0.5.2 h1:LbtPTcP8A5k9WPXj54PPPbjcI4Y6lhyOZXn+VS7wNko=
-go.uber.org/mock v0.5.2/go.mod h1:wLlUxC2vVTPTaE3UD51E0BGOAElKrILxhVSDYQLld5o=
 go.uber.org/multierr v1.11.0 h1:blXXJkSxSSfBVBlC76pxqeO+LN3aDfLQo+309xJstO0=
 go.uber.org/multierr v1.11.0/go.mod h1:20+QtiLqy0Nd6FdQB9TLXag12DsQkrbs3htMFfDN80Y=
 golang.org/x/sys v0.29.0 h1:TPYlXGxvx1MGTn2GiZDhnjPA9wZzZeGKHHmKhHYvgaU=

--- a/mise.toml
+++ b/mise.toml
@@ -1,3 +1,3 @@
 [tools]
-go = "1.24"
-golangci-lint = "2.3.0"
+go = "1.26"
+golangci-lint = "2.11.4"

--- a/mise.toml
+++ b/mise.toml
@@ -1,3 +1,3 @@
 [tools]
-go = "1.26"
+go = "1.26.2"
 golangci-lint = "2.11.4"


### PR DESCRIPTION
## Summary
- raise the module Go version to `1.25.0` and pin the toolchain to `go1.26.2`
- update CI, Pages, and Docker builds to read the Go version from `go.mod` or use a compatible Go image
- refresh local tooling and README examples to match the current Go and `golangci-lint` versions
- remove the unused `go.uber.org/mock` dependency entries from `go.mod` and `go.sum`

## Why
The repository was still split across older Go versions in `go.mod`, GitHub Actions, Docker, and local tooling config.
This change brings those entry points back into sync and fixes failures caused by running the project with an older Go toolchain.

## Notes
- `go.mod` now declares `go 1.25.0`
- the toolchain is pinned separately as `go1.26.2`