### PR TITLE
Improve container image build performance

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+.git
+.github
+.devcontainer
+.vscode
+.cache
+docs/public

--- a/.github/workflows/build-container-image.yaml
+++ b/.github/workflows/build-container-image.yaml
@@ -13,6 +13,7 @@ on:
       - synchronize
       - reopened
     paths:
+      - ".dockerignore"
       - ".github/workflows/build-container-image.yaml"
       - "docker/**"
       - "**/*.go"

--- a/.github/workflows/build-container-image.yaml
+++ b/.github/workflows/build-container-image.yaml
@@ -33,6 +33,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Set up QEMU
+        if: ${{ github.event_name != 'pull_request' }}
         uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -63,13 +64,13 @@ jobs:
         with:
           context: .
           file: ./docker/Dockerfile
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ github.event_name == 'pull_request' && 'linux/amd64' || 'linux/amd64,linux/arm64' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           push: ${{ github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')) }}
-          provenance: mode=max
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          provenance: ${{ github.event_name == 'push' && 'mode=max' || false }}
+          cache-from: type=gha,scope=build-container-image
+          cache-to: type=gha,mode=max,scope=build-container-image
       - name: Display image digest
         run: echo ${{ steps.docker_build.outputs.digest }}
 

--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ go.work
 **/example/**
 
 .gocache
+.cache

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-# syntax=docker/dockerfile:1.7
+# syntax=docker/dockerfile:1
 FROM golang:1.26.2-alpine3.23 AS builder
 
 WORKDIR /src

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,23 +1,26 @@
+# syntax=docker/dockerfile:1.7
 FROM golang:1.26.2-alpine3.23 AS builder
 
-RUN apk add --no-cache git gcc musl-dev
-
-WORKDIR /go/src/github.com/rokuosan/github-issue-cms
-
-ENV GO111MODULE=on
+WORKDIR /src
 
 COPY go.mod go.sum ./
-RUN go mod download
+RUN --mount=type=cache,target=/go/pkg/mod \
+    go mod download
 
 COPY . .
 
-RUN go build -o /go/bin/github-issue-cms .
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    CGO_ENABLED=0 GOOS=linux \
+    go build -trimpath -ldflags="-s -w" -o /out/github-issue-cms .
 
 FROM alpine:3.22
 
-RUN apk add --no-cache ca-certificates
+RUN adduser -D -u 10001 app && apk add --no-cache ca-certificates
 
-COPY --from=builder /go/bin/github-issue-cms /usr/local/bin/github-issue-cms
+COPY --from=builder /out/github-issue-cms /usr/local/bin/github-issue-cms
+
+USER app
 
 ENTRYPOINT ["/usr/local/bin/github-issue-cms"]
 CMD ["--help"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -16,9 +16,13 @@ RUN --mount=type=cache,target=/go/pkg/mod \
 
 FROM alpine:3.22
 
-RUN adduser -D -u 10001 app && apk add --no-cache ca-certificates
+RUN adduser -D -u 10001 app && apk add --no-cache ca-certificates \
+    && mkdir -p /work \
+    && chown app:app /work
 
 COPY --from=builder /out/github-issue-cms /usr/local/bin/github-issue-cms
+
+WORKDIR /work
 
 USER app
 


### PR DESCRIPTION
## Summary
- reduce pull request build time by building only `linux/amd64` in CI while keeping multi-arch builds for pushes and tags
- speed up Docker builds with BuildKit cache mounts and a smaller build context
- slim down the runtime image by building a static binary and running it as a non-root user
- ignore local `.cache` artifacts generated during development

## Why
The container image workflow was spending unnecessary time on emulated multi-platform builds in pull requests.
This change keeps release builds intact while making PR validation faster and tightening the runtime image setup.