### PR TITLE
feat: add version subcommand and inject CLI version in container builds

### DIFF
--- a/.github/workflows/build-container-image.yaml
+++ b/.github/workflows/build-container-image.yaml
@@ -39,6 +39,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
       - name: Login to GitHub Container Registry
+        if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') }}
         uses: docker/login-action@v4
         with:
           registry: ghcr.io
@@ -65,18 +66,20 @@ jobs:
         with:
           context: .
           file: ./docker/Dockerfile
+          build-args: |
+            VERSION=${{ steps.meta.outputs.version }}
           platforms: ${{ github.event_name == 'pull_request' && 'linux/amd64' || 'linux/amd64,linux/arm64' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          push: ${{ github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')) }}
-          provenance: ${{ github.event_name == 'push' && 'mode=max' || false }}
+          push: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') }}
+          provenance: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && 'mode=max' || false }}
           cache-from: type=gha,scope=build-container-image
           cache-to: type=gha,mode=max,scope=build-container-image
       - name: Display image digest
         run: echo ${{ steps.docker_build.outputs.digest }}
 
       - name: Generate artifact attestation
-        if: ${{ github.event_name == 'push' }}
+        if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') }}
         uses: actions/attest-build-provenance@v4
         with:
           subject-name: ghcr.io/${{ github.repository }}

--- a/cmd/cli/cli.go
+++ b/cmd/cli/cli.go
@@ -11,6 +11,9 @@ import (
 
 var verbosity int
 
+// Version is the application version and can be overridden at build time with -ldflags.
+var Version = "dev"
+
 // NewRootCommand creates the root command.
 func NewRootCommand() *cobra.Command {
 	verbosity = 0
@@ -36,6 +39,7 @@ with frontmatter and downloads attached images.`,
 	// Register subcommands.
 	rootCmd.AddCommand(subcommand.NewGenerateCommand())
 	rootCmd.AddCommand(subcommand.NewInitCommand())
+	rootCmd.AddCommand(subcommand.NewVersionCommand(&Version))
 
 	return rootCmd
 }

--- a/cmd/cli/cli_test.go
+++ b/cmd/cli/cli_test.go
@@ -1,10 +1,12 @@
 package cli
 
 import (
+	"bytes"
 	"log/slog"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNewRootCommand(t *testing.T) {
@@ -16,20 +18,23 @@ func TestNewRootCommand(t *testing.T) {
 
 	// Ensure subcommands are registered.
 	commands := cmd.Commands()
-	assert.GreaterOrEqual(t, len(commands), 2, "Should have at least 2 subcommands")
+	assert.GreaterOrEqual(t, len(commands), 3, "Should have at least 3 subcommands")
 
-	var hasGenerate, hasInit bool
+	var hasGenerate, hasInit, hasVersion bool
 	for _, subCmd := range commands {
 		switch subCmd.Use {
 		case "generate":
 			hasGenerate = true
 		case "init":
 			hasInit = true
+		case "version":
+			hasVersion = true
 		}
 	}
 
 	assert.True(t, hasGenerate, "Should have 'generate' subcommand")
 	assert.True(t, hasInit, "Should have 'init' subcommand")
+	assert.True(t, hasVersion, "Should have 'version' subcommand")
 }
 
 func TestRootCommand_Flags(t *testing.T) {
@@ -51,10 +56,19 @@ func TestRootCommand_Help(t *testing.T) {
 
 func TestRootCommand_Version(t *testing.T) {
 	cmd := NewRootCommand()
+	var stdout bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetArgs([]string{"version"})
 
-	// Version information is not available yet, but may be added later.
-	// For now, just ensure the command is constructed correctly.
-	assert.NotNil(t, cmd)
+	originalVersion := Version
+	Version = "v9.9.9"
+	t.Cleanup(func() {
+		Version = originalVersion
+	})
+
+	err := cmd.Execute()
+	require.NoError(t, err)
+	assert.Equal(t, "v9.9.9\n", stdout.String())
 }
 
 func TestRootCommand_InvalidSubcommand(t *testing.T) {

--- a/cmd/cli/subcommand/version.go
+++ b/cmd/cli/subcommand/version.go
@@ -1,0 +1,27 @@
+package subcommand
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+// NewVersionCommand creates the version subcommand.
+func NewVersionCommand(version *string) *cobra.Command {
+	return &cobra.Command{
+		Use:   "version",
+		Short: "Print the application version",
+		Long: `Print the application version.
+
+Examples:
+  github-issue-cms version`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if version == nil {
+				return fmt.Errorf("version is not set")
+			}
+
+			_, err := fmt.Fprintln(cmd.OutOrStdout(), *version)
+			return err
+		},
+	}
+}

--- a/cmd/cli/subcommand/version_test.go
+++ b/cmd/cli/subcommand/version_test.go
@@ -1,0 +1,37 @@
+package subcommand
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewVersionCommand(t *testing.T) {
+	version := "v1.2.3"
+	cmd := NewVersionCommand(&version)
+
+	assert.NotNil(t, cmd)
+	assert.Equal(t, "version", cmd.Use)
+	assert.Contains(t, cmd.Short, "version")
+}
+
+func TestVersionCommand_PrintsVersion(t *testing.T) {
+	version := "v1.2.3"
+	cmd := NewVersionCommand(&version)
+	var stdout bytes.Buffer
+	cmd.SetOut(&stdout)
+
+	err := cmd.Execute()
+	require.NoError(t, err)
+	assert.Equal(t, "v1.2.3\n", stdout.String())
+}
+
+func TestVersionCommand_WithoutVersion(t *testing.T) {
+	cmd := NewVersionCommand(nil)
+
+	err := cmd.Execute()
+	assert.Error(t, err)
+	assert.ErrorContains(t, err, "version is not set")
+}

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,6 +2,7 @@
 FROM golang:1.26.2-alpine3.23 AS builder
 
 WORKDIR /src
+ARG VERSION=dev
 
 COPY go.mod go.sum ./
 RUN --mount=type=cache,target=/go/pkg/mod \
@@ -12,7 +13,7 @@ COPY . .
 RUN --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.cache/go-build \
     CGO_ENABLED=0 GOOS=linux \
-    go build -trimpath -ldflags="-s -w" -o /out/github-issue-cms .
+    go build -trimpath -ldflags="-s -w -X github.com/rokuosan/github-issue-cms/cmd/cli.Version=${VERSION}" -o /out/github-issue-cms .
 
 FROM alpine:3.23
 


### PR DESCRIPTION
## Summary

- add a `version` subcommand to print the CLI version
- inject `cmd/cli.Version` at build time via `-ldflags` in the container build
- update the container image workflow to publish to GHCR only on tag builds

## Details

- default the CLI version to `dev` and allow overriding it at build time
- add tests for the new `version` subcommand and root command wiring
- pass the version from the container build workflow into the Docker build as a build arg

## Testing

- `go test ./...`
