### PR TITLE
automate GitHub Releases for CLI binaries

### DIFF
--- a/.github/workflows/release-golang.yaml
+++ b/.github/workflows/release-golang.yaml
@@ -1,0 +1,34 @@
+name: Release Go Binary
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: go.mod
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@f82bb3a3596c2705d0163a7633949f35b28cbf75 # v6.3.0
+        with:
+          distribution: goreleaser
+          version: "~> v2"
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,5 @@ go.work
 
 .gocache
 .cache
+
+dist

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,61 @@
+version: 2
+
+project_name: github-issue-cms
+
+before:
+  hooks:
+    - go mod tidy
+    - go test ./...
+
+builds:
+  - id: github-issue-cms
+    main: .
+    binary: github-issue-cms
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - darwin
+      - linux
+      - windows
+    goarch:
+      - amd64
+      - arm64
+    ignore:
+      - goos: windows
+        goarch: arm64
+    ldflags:
+      - -s -w -X github.com/rokuosan/github-issue-cms/cmd/cli.Version={{ .Version }}
+
+archives:
+  - id: default
+    ids:
+      - github-issue-cms
+    formats:
+      - tar.gz
+    format_overrides:
+      - goos: windows
+        formats:
+          - zip
+    name_template: >-
+      {{ .ProjectName }}_
+      {{- .Version }}_
+      {{- .Os }}_
+      {{- .Arch }}
+
+checksum:
+  name_template: checksums.txt
+
+changelog:
+  use: github
+  sort: asc
+  filters:
+    exclude:
+      - "^docs:"
+      - "^test:"
+      - "^chore:"
+
+release:
+  github:
+    owner: rokuosan
+    name: github-issue-cms
+  prerelease: auto

--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ Issues are treated as articles.
 $ go install github.com/rokuosan/github-issue-cms@v0.6.1
 ```
 
+GitHub Releases also publish prebuilt binaries for macOS, Linux, and Windows.
+
 ### 2. Create Config file
 
 Create a YAML file named ``gic.config.yaml`` and write your credentials.
@@ -115,3 +117,30 @@ jobs:
 Congratulations.
 
 Your Hugo site content will be regenerated and committed automatically when you push to `main` or an issue is closed or reopened.
+
+## Release automation
+
+This repository publishes CLI binaries to GitHub Releases automatically when a tag matching `v*` is pushed.
+
+Artifacts:
+
+- `github-issue-cms_<version>_darwin_amd64.tar.gz`
+- `github-issue-cms_<version>_darwin_arm64.tar.gz`
+- `github-issue-cms_<version>_linux_amd64.tar.gz`
+- `github-issue-cms_<version>_linux_arm64.tar.gz`
+- `github-issue-cms_<version>_windows_amd64.zip`
+- `checksums.txt`
+
+Release flow:
+
+```bash
+git tag v0.6.2
+git push origin v0.6.2
+```
+
+For local validation:
+
+```bash
+task release:check
+task release:snapshot
+```

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -35,3 +35,13 @@ tasks:
     desc: "Run tests."
     cmds:
       - "go test -v ./..."
+
+  release:check:
+    desc: "Validate GoReleaser config."
+    cmds:
+      - "goreleaser check"
+
+  release:snapshot:
+    desc: "Build release artifacts locally without publishing."
+    cmds:
+      - "goreleaser release --snapshot --clean"

--- a/mise.toml
+++ b/mise.toml
@@ -1,3 +1,4 @@
 [tools]
 go = "1.26.2"
 golangci-lint = "2.11.4"
+goreleaser = "2.15.4"


### PR DESCRIPTION
## Summary
- add GoReleaser configuration for cross-platform CLI release artifacts
- add a tag-triggered GitHub Actions workflow to publish GitHub Releases on v* tags
- add local validation tasks and document the release flow in the README

## Why
The repository already published container images on release tags, but it did not create GitHub Releases for the CLI binary itself. This change makes tagged releases publish versioned binaries and checksums alongside the existing container image flow.

## Validation
- go test ./...
- verified that v* tags are wired to both the existing container workflow and the new GoReleaser workflow
- documented local dry-run commands via task release:check and task release:snapshot
