### PR TITLE
ci: use GitHub native release notes

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -46,13 +46,7 @@ checksum:
   name_template: checksums.txt
 
 changelog:
-  use: github
-  sort: asc
-  filters:
-    exclude:
-      - "^docs:"
-      - "^test:"
-      - "^chore:"
+  use: github-native
 
 release:
   github:


### PR DESCRIPTION
## Summary
- switch GoReleaser changelog generation from github to github-native
- rely on GitHub release note generation to aggregate changes by pull request instead of commit
- remove changelog sorting and commit-message filters that no longer apply with github-native

## Testing
- goreleaser check