### PR TITLE
Refactor config schema to use `output` and add config migration command

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,12 @@
-# GitHub Issue-based headless CMS for Hugo
+# GitHub Issue-based headless CMS
 
-A headless CMS for Hugo using GitHub Issues.
+A headless CMS using GitHub Issues.
 
 Issues are treated as articles.
 
 ## Prerequisites
 
 - Go
-- Hugo
 - GitHub Token
 
 ## Installation
@@ -29,16 +28,18 @@ github:
   username: '<YOUR_GITHUB_USERNAME>'
   repository: '<YOUR_GITHUB_REPOSITORY>'
 
-hugo:
-  filename:
-    articles: '%Y-%m-%d_%H%M%S.md'
-    images: '[:id].png'
-  directory:
-    articles: 'content/posts'
-    images: 'static/images/%Y-%m-%d_%H%M%S'
-  url:
-    images: '/images/%Y-%m-%d_%H%M%S'
+output:
+  articles:
+    directory: 'content/posts'
+    filename: '%Y-%m-%d_%H%M%S.md'
+  images:
+    directory: 'static/images/%Y-%m-%d_%H%M%S'
+    filename: '[:id].png'
+    url: '/images/%Y-%m-%d_%H%M%S'
 ```
+
+If you already have a legacy `hugo:` config section, it is still readable in `v1.0.0`.
+Run `github-issue-cms migrate` to rewrite it to the canonical `output:` schema.
 
 ### 3. Run
 
@@ -50,7 +51,7 @@ $ github-issue-cms generate --token="YOUR_GITHUB_TOKEN"
 
 If your repository has issues and attached images, they will be exported like this tree.
 
-These directories are compatible with Hugo directory structure, so you can quickly deploy this application to your Hugo site.
+These output paths are configurable, so you can adapt them to your site or build pipeline.
 
 ```bash
 $ tree --dirsfirst

--- a/cmd/cli/cli.go
+++ b/cmd/cli/cli.go
@@ -21,12 +21,12 @@ func NewRootCommand() *cobra.Command {
 
 	rootCmd := &cobra.Command{
 		Use:           "github-issue-cms",
-		Short:         "Generate articles from GitHub issues for Hugo",
+		Short:         "Generate articles from GitHub issues",
 		SilenceErrors: true,
 		SilenceUsage:  true,
-		Long: `GitHub Issue-based headless CMS for Hugo.
+		Long: `GitHub Issue-based headless CMS.
 
-This tool converts GitHub Issues into Hugo-compatible markdown articles
+This tool converts GitHub Issues into markdown articles
 with frontmatter and downloads attached images.`,
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
 			configureLogger(verbosity)
@@ -39,6 +39,7 @@ with frontmatter and downloads attached images.`,
 	// Register subcommands.
 	rootCmd.AddCommand(subcommand.NewGenerateCommand())
 	rootCmd.AddCommand(subcommand.NewInitCommand())
+	rootCmd.AddCommand(subcommand.NewMigrateCommand())
 	rootCmd.AddCommand(subcommand.NewVersionCommand(&Version))
 
 	return rootCmd

--- a/cmd/cli/cli_test.go
+++ b/cmd/cli/cli_test.go
@@ -18,15 +18,17 @@ func TestNewRootCommand(t *testing.T) {
 
 	// Ensure subcommands are registered.
 	commands := cmd.Commands()
-	assert.GreaterOrEqual(t, len(commands), 3, "Should have at least 3 subcommands")
+	assert.GreaterOrEqual(t, len(commands), 4, "Should have at least 4 subcommands")
 
-	var hasGenerate, hasInit, hasVersion bool
+	var hasGenerate, hasInit, hasMigrate, hasVersion bool
 	for _, subCmd := range commands {
 		switch subCmd.Use {
 		case "generate":
 			hasGenerate = true
 		case "init":
 			hasInit = true
+		case "migrate":
+			hasMigrate = true
 		case "version":
 			hasVersion = true
 		}
@@ -34,6 +36,7 @@ func TestNewRootCommand(t *testing.T) {
 
 	assert.True(t, hasGenerate, "Should have 'generate' subcommand")
 	assert.True(t, hasInit, "Should have 'init' subcommand")
+	assert.True(t, hasMigrate, "Should have 'migrate' subcommand")
 	assert.True(t, hasVersion, "Should have 'version' subcommand")
 }
 

--- a/cmd/cli/subcommand/generate.go
+++ b/cmd/cli/subcommand/generate.go
@@ -20,7 +20,7 @@ func NewGenerateCommand() *cobra.Command {
 		Long: `Generate articles from GitHub issues.
 
 This command will get issues from GitHub and create articles from them.
-The articles will be saved in the Hugo-compatible directory structure
+The articles will be saved in the configured output directory structure
 specified in gic.config.yaml.
 
 Examples:

--- a/cmd/cli/subcommand/init.go
+++ b/cmd/cli/subcommand/init.go
@@ -21,7 +21,7 @@ func NewInitCommand() *cobra.Command {
 		Short: "Generate config file",
 		Long: `Generate config file named "gic.config.yaml" in the current directory.
 
-This command creates a configuration file with default settings for Hugo integration.
+This command creates a configuration file with default output settings.
 You can specify GitHub username and repository using flags.
 
 Examples:

--- a/cmd/cli/subcommand/migrate.go
+++ b/cmd/cli/subcommand/migrate.go
@@ -1,0 +1,49 @@
+package subcommand
+
+import (
+	"fmt"
+	"log/slog"
+
+	"github.com/rokuosan/github-issue-cms/pkg/config"
+	"github.com/spf13/cobra"
+)
+
+// NewMigrateCommand creates the migrate subcommand.
+func NewMigrateCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "migrate",
+		Short: "Rewrite config to the latest schema",
+		Long: `Rewrite gic.config.yaml to the latest schema.
+
+This command reads the current configuration, keeps legacy keys readable,
+and writes the canonical config format back to disk.
+
+Examples:
+  github-issue-cms migrate`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runMigrate()
+		},
+	}
+
+	return cmd
+}
+
+func runMigrate() error {
+	conf, err := config.Reload()
+	if err != nil {
+		return fmt.Errorf("failed to load config: %w", err)
+	}
+
+	hadLegacyHugo := conf.Hugo != nil
+	if err := config.Write(conf); err != nil {
+		return fmt.Errorf("failed to write migrated config: %w", err)
+	}
+
+	if hadLegacyHugo {
+		slog.Info("Configuration migrated from 'hugo' to 'output': " + config.GetConfigPath())
+		return nil
+	}
+
+	slog.Info("Configuration rewritten in the latest schema: " + config.GetConfigPath())
+	return nil
+}

--- a/cmd/cli/subcommand/migrate_test.go
+++ b/cmd/cli/subcommand/migrate_test.go
@@ -1,0 +1,70 @@
+package subcommand
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/rokuosan/github-issue-cms/pkg/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewMigrateCommand(t *testing.T) {
+	cmd := NewMigrateCommand()
+
+	assert.NotNil(t, cmd)
+	assert.Equal(t, "migrate", cmd.Use)
+	assert.Contains(t, cmd.Short, "latest schema")
+}
+
+func TestMigrateCommand_Help(t *testing.T) {
+	cmd := NewMigrateCommand()
+	cmd.SetArgs([]string{"--help"})
+
+	err := cmd.Execute()
+	assert.NoError(t, err)
+}
+
+func TestMigrateCommand_RewritesLegacyHugoConfig(t *testing.T) {
+	tempDir := t.TempDir()
+
+	originalWd, err := os.Getwd()
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, os.Chdir(originalWd))
+	})
+
+	require.NoError(t, os.Chdir(tempDir))
+
+	legacy := `github:
+  username: "testuser"
+  repository: "testrepo"
+hugo:
+  directory:
+    articles: "content/posts"
+    images: "static/images/%Y-%m-%d"
+  filename:
+    articles: "index.md"
+    images: "[:id].png"
+  url:
+    images: "/images/%Y-%m-%d"
+`
+	configPath := filepath.Join(tempDir, config.ConfigFileName+"."+config.ConfigFileType)
+	require.NoError(t, os.WriteFile(configPath, []byte(legacy), 0o644))
+
+	cmd := NewMigrateCommand()
+	err = cmd.Execute()
+	require.NoError(t, err)
+
+	data, err := os.ReadFile(configPath)
+	require.NoError(t, err)
+
+	content := string(data)
+	assert.Contains(t, content, "output:")
+	assert.Contains(t, content, "articles:")
+	assert.Contains(t, content, "directory: content/posts")
+	assert.Contains(t, content, "filename: index.md")
+	assert.Contains(t, content, "url: /images/%Y-%m-%d")
+	assert.NotContains(t, content, "\nhugo:")
+}

--- a/docs/content/configuration/parameters.ja.md
+++ b/docs/content/configuration/parameters.ja.md
@@ -15,15 +15,14 @@ github:
   username: 'rokuosan'
   repository: 'github-issue-cms'
 
-hugo:
-  filename:
-    articles: '%Y-%m-%d_%H%M%S.md'
-    images: '[:id].png'
-  directory:
-    articles: 'content/posts'
-    images: 'static/images/%Y-%m-%d_%H%M%S'
-  url:
-    images: '/images/%Y-%m-%d_%H%M%S'
+output:
+  articles:
+    directory: 'content/posts'
+    filename: '%Y-%m-%d_%H%M%S.md'
+  images:
+    directory: 'static/images/%Y-%m-%d_%H%M%S'
+    filename: '[:id].png'
+    url: '/images/%Y-%m-%d_%H%M%S'
 ```
 
 ## 設定項目
@@ -35,25 +34,22 @@ GitHub の設定です。
 - `username`: GitHub のユーザー名
 - `repository`: Issue を取得するリポジトリ名
 
-### `hugo`
+### `output`
 
-Hugo の設定です。
+出力先の設定です。
 
-#### `filename`
+#### `articles`
 
-- `articles`: 記事のファイル名
-- `images`: 画像のファイル名
+- `directory`: 記事の保存先ディレクトリ
+- `filename`: 記事のファイル名
+
+#### `images`
+
+- `directory`: 画像の保存先ディレクトリ
+- `filename`: 画像のファイル名
+- `url`: Markdownから参照される画像のURL
 
 ``[:id]`` は画像の ID に置き換わります。画像の ID はそのIssue内部で一意で、連番で割り振られます。
-
-#### `directory`
-
-- `articles`: 記事の保存先ディレクトリ
-- `images`: 画像の保存先ディレクトリ
-
-#### `url`
-
-- `images`: Markdownから参照される画像のURL
 
 ## プレースホルダ
 
@@ -74,15 +70,14 @@ Hugo の設定です。
 
 #### `gic.config.yaml`
 ```yaml
-hugo:
-  filename:
-    articles: 'index.md'
-    images: '[:id].png'
-  directory:
-    articles: 'content/posts/%Y-%m-%d_%H%M%S'
-    images: 'content/posts/%Y-%m-%d_%H%M%S'
-  url:
-    images: ''
+output:
+  articles:
+    directory: 'content/posts/%Y-%m-%d_%H%M%S'
+    filename: 'index.md'
+  images:
+    directory: 'content/posts/%Y-%m-%d_%H%M%S'
+    filename: '[:id].png'
+    url: ''
 ```
 
 #### 出力例

--- a/docs/content/configuration/parameters.md
+++ b/docs/content/configuration/parameters.md
@@ -15,15 +15,14 @@ github:
   username: 'rokuosan'
   repository: 'github-issue-cms'
 
-hugo:
-  filename:
-    articles: '%Y-%m-%d_%H%M%S.md'
-    images: '[:id].png'
-  directory:
-    articles: 'content/posts'
-    images: 'static/images/%Y-%m-%d_%H%M%S'
-  url:
-    images: '/images/%Y-%m-%d_%H%M%S'
+output:
+  articles:
+    directory: 'content/posts'
+    filename: '%Y-%m-%d_%H%M%S.md'
+  images:
+    directory: 'static/images/%Y-%m-%d_%H%M%S'
+    filename: '[:id].png'
+    url: '/images/%Y-%m-%d_%H%M%S'
 ```
 
 ## Configuration Items
@@ -35,25 +34,22 @@ GitHub settings.
 - `username`: GitHub username
 - `repository`: Repository name to fetch issues from
 
-### `hugo`
+### `output`
 
-Hugo settings.
+Output settings.
 
-#### `filename`
+#### `articles`
 
-- `articles`: Article filename
-- `images`: Image filename
+- `directory`: Directory to save articles
+- `filename`: Article filename
+
+#### `images`
+
+- `directory`: Directory to save images
+- `filename`: Image filename
+- `url`: Image URL referenced from Markdown
 
 `[:id]` will be replaced with the image ID. The image ID is unique within each issue and assigned sequentially.
-
-#### `directory`
-
-- `articles`: Directory to save articles
-- `images`: Directory to save images
-
-#### `url`
-
-- `images`: Image URL referenced from Markdown
 
 ## Placeholders
 
@@ -74,15 +70,14 @@ These placeholders can be used in the same format as `strftime`.
 
 #### `gic.config.yaml`
 ```yaml
-hugo:
-  filename:
-    articles: 'index.md'
-    images: '[:id].png'
-  directory:
-    articles: 'content/posts/%Y-%m-%d_%H%M%S'
-    images: 'content/posts/%Y-%m-%d_%H%M%S'
-  url:
-    images: ''
+output:
+  articles:
+    directory: 'content/posts/%Y-%m-%d_%H%M%S'
+    filename: 'index.md'
+  images:
+    directory: 'content/posts/%Y-%m-%d_%H%M%S'
+    filename: '[:id].png'
+    url: ''
 ```
 
 #### Output Example

--- a/docs/content/quickstart.ja.md
+++ b/docs/content/quickstart.ja.md
@@ -38,15 +38,14 @@ github:
   username: '<YOUR_GITHUB_USERNAME>'
   repository: '<YOUR_GITHUB_REPOSITORY>'
 
-hugo:
-  filename:
-    articles: '%Y-%m-%d_%H%M%S.md'
-    images: '[:id].png'
-  directory:
-    articles: 'content/posts'
-    images: 'static/images/%Y-%m-%d_%H%M%S'
-  url:
-    images: '/images/%Y-%m-%d_%H%M%S'
+output:
+  articles:
+    directory: 'content/posts'
+    filename: '%Y-%m-%d_%H%M%S.md'
+  images:
+    directory: 'static/images/%Y-%m-%d_%H%M%S'
+    filename: '[:id].png'
+    url: '/images/%Y-%m-%d_%H%M%S'
 ```
 
 ### 3. 実行

--- a/docs/content/quickstart.md
+++ b/docs/content/quickstart.md
@@ -38,15 +38,14 @@ github:
   username: '<YOUR_GITHUB_USERNAME>'
   repository: '<YOUR_GITHUB_REPOSITORY>'
 
-hugo:
-  filename:
-    articles: '%Y-%m-%d_%H%M%S.md'
-    images: '[:id].png'
-  directory:
-    articles: 'content/posts'
-    images: 'static/images/%Y-%m-%d_%H%M%S'
-  url:
-    images: '/images/%Y-%m-%d_%H%M%S'
+output:
+  articles:
+    directory: 'content/posts'
+    filename: '%Y-%m-%d_%H%M%S.md'
+  images:
+    directory: 'static/images/%Y-%m-%d_%H%M%S'
+    filename: '[:id].png'
+    url: '/images/%Y-%m-%d_%H%M%S'
 ```
 
 ### 3. Execute

--- a/gic.config.yaml
+++ b/gic.config.yaml
@@ -2,23 +2,21 @@ github:
   username: 'rokuosan'
   repository: 'github-issue-cms'
 
-hugo:
-  filename:
-    articles: '%Y-%m-%d_%H%M%S.md'
-    images: '[:id].png'
-  directory:
-    articles: 'content/posts'
-    images: 'static/images/%Y-%m-%d_%H%M%S'
-  url:
-    images: '/images/%Y-%m-%d_%H%M%S'
+output:
+  articles:
+    directory: 'content/posts'
+    filename: '%Y-%m-%d_%H%M%S.md'
+  images:
+    directory: 'static/images/%Y-%m-%d_%H%M%S'
+    filename: '[:id].png'
+    url: '/images/%Y-%m-%d_%H%M%S'
 
 # For page bundle
-# hugo:
-#   filename:
-#     articles: 'index.md'
-#     images: '[:id].png'
-#   directory:
-#     articles: 'content/posts/%Y-%m-%d_%H%M%S'
-#     images: 'content/posts/%Y-%m-%d_%H%M%S'
-#   url:
-#     images: ''
+# output:
+#   articles:
+#     directory: 'content/posts/%Y-%m-%d_%H%M%S'
+#     filename: 'index.md'
+#   images:
+#     directory: 'content/posts/%Y-%m-%d_%H%M%S'
+#     filename: '[:id].png'
+#     url: ''

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -29,6 +29,7 @@ func load() error {
 		return err
 	}
 
+	config.normalize()
 	return config.validate()
 }
 
@@ -41,23 +42,20 @@ func Reload() (Config, error) {
 
 // Generate generates a configuration file.
 func Generate() error {
-	viperInitialize()
+	return Write(*NewConfig())
+}
 
-	c := NewConfig()
+// Write writes the configuration file using the canonical schema.
+func Write(conf Config) error {
+	conf.normalize()
+	conf.Hugo = nil
 
-	data, err := yaml.Marshal(c)
+	data, err := yaml.Marshal(conf)
 	if err != nil {
 		return err
 	}
 
-	file, err := os.Create(GetConfigPath())
-	if err != nil {
-		return err
-	}
-	defer file.Close()
-
-	_, err = file.Write(data)
-	return err
+	return os.WriteFile(GetConfigPath(), data, 0o644)
 }
 
 // Get returns a configuration.

--- a/pkg/config/type.go
+++ b/pkg/config/type.go
@@ -25,9 +25,9 @@ type OutputArticlesConfig struct {
 }
 
 type OutputImagesConfig struct {
-	Directory string `yaml:"directory" mapstructure:"directory"`
-	Filename  string `yaml:"filename" mapstructure:"filename"`
-	URL       string `yaml:"url" mapstructure:"url"`
+	Directory string  `yaml:"directory" mapstructure:"directory"`
+	Filename  string  `yaml:"filename" mapstructure:"filename"`
+	BaseURL   *string `yaml:"url" mapstructure:"url"`
 }
 
 type HugoConfig struct {
@@ -98,11 +98,19 @@ func NewOutputArticlesConfig() *OutputArticlesConfig {
 }
 
 func NewOutputImagesConfig() *OutputImagesConfig {
+	url := "/images/%Y-%m-%d_%H%M%S"
 	return &OutputImagesConfig{
 		Directory: "static/images/%Y-%m-%d_%H%M%S",
 		Filename:  "[:id].png",
-		URL:       "/images/%Y-%m-%d_%H%M%S",
+		BaseURL:   &url,
 	}
+}
+
+func (c *OutputImagesConfig) URL() string {
+	if c == nil || c.BaseURL == nil {
+		return ""
+	}
+	return *c.BaseURL
 }
 
 func (c *Config) normalize() {
@@ -144,8 +152,9 @@ func (c *Config) normalize() {
 		if c.Output.Images.Filename == "" {
 			c.Output.Images.Filename = c.Hugo.Images.Filename
 		}
-		if c.Output.Images.URL == "" {
-			c.Output.Images.URL = c.Hugo.Images.URL
+		if c.Output.Images.BaseURL == nil {
+			url := c.Hugo.Images.URL
+			c.Output.Images.BaseURL = &url
 		}
 	}
 
@@ -165,7 +174,8 @@ func (c *Config) normalize() {
 			c.Output.Images.Filename = c.Hugo.Filename.Images
 		}
 	}
-	if c.Hugo.Url != nil && c.Output.Images.URL == "" {
-		c.Output.Images.URL = c.Hugo.Url.Images
+	if c.Hugo.Url != nil && c.Output.Images.BaseURL == nil {
+		url := c.Hugo.Url.Images
+		c.Output.Images.BaseURL = &url
 	}
 }

--- a/pkg/config/type.go
+++ b/pkg/config/type.go
@@ -4,35 +4,65 @@ package config
 // If you change the configuration, you also need to change ``config.Generate()`` (config.go).
 
 type Config struct {
-	GitHub *GitHubConfig `yaml:"github"`
-	Hugo   *HugoConfig   `yaml:"hugo"`
+	GitHub *GitHubConfig `yaml:"github" mapstructure:"github"`
+	Output *OutputConfig `yaml:"output" mapstructure:"output"`
+	Hugo   *HugoConfig   `yaml:"hugo,omitempty" mapstructure:"hugo"`
 }
 
 type GitHubConfig struct {
-	Username   string `yaml:"username"`
-	Repository string `yaml:"repository"`
+	Username   string `yaml:"username" mapstructure:"username"`
+	Repository string `yaml:"repository" mapstructure:"repository"`
+}
+
+type OutputConfig struct {
+	Articles *OutputArticlesConfig `yaml:"articles" mapstructure:"articles"`
+	Images   *OutputImagesConfig   `yaml:"images" mapstructure:"images"`
+}
+
+type OutputArticlesConfig struct {
+	Directory string `yaml:"directory" mapstructure:"directory"`
+	Filename  string `yaml:"filename" mapstructure:"filename"`
+}
+
+type OutputImagesConfig struct {
+	Directory string `yaml:"directory" mapstructure:"directory"`
+	Filename  string `yaml:"filename" mapstructure:"filename"`
+	URL       string `yaml:"url" mapstructure:"url"`
 }
 
 type HugoConfig struct {
-	Bundle    string               `yaml:"bundle,omitempty"`
-	Directory *HugoDirectoryConfig `yaml:"directory"`
-	Filename  *HugoFilenameConfig  `yaml:"filename"`
-	Url       *HugoURLConfig       `yaml:"url"`
+	Content   *HugoContentConfig   `yaml:"content,omitempty" mapstructure:"content"`
+	Images    *HugoImagesConfig    `yaml:"images,omitempty" mapstructure:"images"`
+	Bundle    string               `yaml:"bundle,omitempty" mapstructure:"bundle"`
+	Directory *HugoDirectoryConfig `yaml:"directory,omitempty" mapstructure:"directory"`
+	Filename  *HugoFilenameConfig  `yaml:"filename,omitempty" mapstructure:"filename"`
+	Url       *HugoURLConfig       `yaml:"url,omitempty" mapstructure:"url"`
+}
+
+type HugoContentConfig struct {
+	Directory string `yaml:"directory" mapstructure:"directory"`
+	Filename  string `yaml:"filename" mapstructure:"filename"`
+}
+
+type HugoImagesConfig struct {
+	Directory string `yaml:"directory" mapstructure:"directory"`
+	Filename  string `yaml:"filename" mapstructure:"filename"`
+	URL       string `yaml:"url" mapstructure:"url"`
 }
 
 type HugoDirectoryConfig struct {
-	Articles string `yaml:"articles"`
-	Images   string `yaml:"images"`
+	Articles string `yaml:"articles" mapstructure:"articles"`
+	Images   string `yaml:"images" mapstructure:"images"`
 }
 
 type HugoFilenameConfig struct {
-	Articles string `yaml:"articles"`
-	Images   string `yaml:"images"`
+	Articles string `yaml:"articles" mapstructure:"articles"`
+	Images   string `yaml:"images" mapstructure:"images"`
 }
 
 type HugoURLConfig struct {
-	AppendSlash bool   `yaml:"appendSlash,omitempty"`
-	Images      string `yaml:"images"`
+	AppendSlash bool   `yaml:"appendSlash,omitempty" mapstructure:"appendSlash"`
+	Images      string `yaml:"images" mapstructure:"images"`
 }
 
 func (c *GitHubConfig) RepositoryURL() string {
@@ -42,7 +72,7 @@ func (c *GitHubConfig) RepositoryURL() string {
 func NewConfig() *Config {
 	return &Config{
 		GitHub: NewGitHubConfig(),
-		Hugo:   NewHugoConfig(),
+		Output: NewOutputConfig(),
 	}
 }
 
@@ -53,30 +83,89 @@ func NewGitHubConfig() *GitHubConfig {
 	}
 }
 
-func NewHugoConfig() *HugoConfig {
-	return &HugoConfig{
-		Directory: NewHugoDirectoryConfig(),
-		Filename:  NewHugoFilenameConfig(),
-		Url:       NewHugoURLConfig(),
+func NewOutputConfig() *OutputConfig {
+	return &OutputConfig{
+		Articles: NewOutputArticlesConfig(),
+		Images:   NewOutputImagesConfig(),
 	}
 }
 
-func NewHugoDirectoryConfig() *HugoDirectoryConfig {
-	return &HugoDirectoryConfig{
-		Articles: "content/posts",
-		Images:   "static/images/%Y-%m-%d_%H%M%S",
+func NewOutputArticlesConfig() *OutputArticlesConfig {
+	return &OutputArticlesConfig{
+		Directory: "content/posts",
+		Filename:  "%Y-%m-%d_%H%M%S.md",
 	}
 }
 
-func NewHugoFilenameConfig() *HugoFilenameConfig {
-	return &HugoFilenameConfig{
-		Articles: "%Y-%m-%d_%H%M%S.md",
-		Images:   "[:id].png",
+func NewOutputImagesConfig() *OutputImagesConfig {
+	return &OutputImagesConfig{
+		Directory: "static/images/%Y-%m-%d_%H%M%S",
+		Filename:  "[:id].png",
+		URL:       "/images/%Y-%m-%d_%H%M%S",
 	}
 }
 
-func NewHugoURLConfig() *HugoURLConfig {
-	return &HugoURLConfig{
-		Images: "/images/%Y-%m-%d_%H%M%S",
+func (c *Config) normalize() {
+	if c.GitHub == nil {
+		c.GitHub = NewGitHubConfig()
+	}
+
+	if c.Output == nil {
+		if c.Hugo != nil {
+			c.Output = &OutputConfig{}
+		} else {
+			c.Output = NewOutputConfig()
+		}
+	}
+
+	if c.Output.Articles == nil {
+		c.Output.Articles = &OutputArticlesConfig{}
+	}
+	if c.Output.Images == nil {
+		c.Output.Images = &OutputImagesConfig{}
+	}
+
+	if c.Hugo == nil {
+		return
+	}
+
+	if c.Hugo.Content != nil {
+		if c.Output.Articles.Directory == "" {
+			c.Output.Articles.Directory = c.Hugo.Content.Directory
+		}
+		if c.Output.Articles.Filename == "" {
+			c.Output.Articles.Filename = c.Hugo.Content.Filename
+		}
+	}
+	if c.Hugo.Images != nil {
+		if c.Output.Images.Directory == "" {
+			c.Output.Images.Directory = c.Hugo.Images.Directory
+		}
+		if c.Output.Images.Filename == "" {
+			c.Output.Images.Filename = c.Hugo.Images.Filename
+		}
+		if c.Output.Images.URL == "" {
+			c.Output.Images.URL = c.Hugo.Images.URL
+		}
+	}
+
+	if c.Hugo.Directory != nil {
+		if c.Output.Articles.Directory == "" {
+			c.Output.Articles.Directory = c.Hugo.Directory.Articles
+		}
+		if c.Output.Images.Directory == "" {
+			c.Output.Images.Directory = c.Hugo.Directory.Images
+		}
+	}
+	if c.Hugo.Filename != nil {
+		if c.Output.Articles.Filename == "" {
+			c.Output.Articles.Filename = c.Hugo.Filename.Articles
+		}
+		if c.Output.Images.Filename == "" {
+			c.Output.Images.Filename = c.Hugo.Filename.Images
+		}
+	}
+	if c.Hugo.Url != nil && c.Output.Images.URL == "" {
+		c.Output.Images.URL = c.Hugo.Url.Images
 	}
 }

--- a/pkg/config/type_test.go
+++ b/pkg/config/type_test.go
@@ -1,0 +1,88 @@
+package config
+
+import "testing"
+
+func TestConfigNormalize_LegacyHugoDirectoryFields(t *testing.T) {
+	conf := Config{
+		GitHub: NewGitHubConfig(),
+		Hugo: &HugoConfig{
+			Directory: &HugoDirectoryConfig{
+				Articles: "content/posts",
+				Images:   "static/images/%Y-%m-%d",
+			},
+			Filename: &HugoFilenameConfig{
+				Articles: "index.md",
+				Images:   "[:id].png",
+			},
+			Url: &HugoURLConfig{
+				Images: "/images/%Y-%m-%d",
+			},
+		},
+	}
+
+	conf.normalize()
+
+	if conf.Output.Articles.Directory != "content/posts" {
+		t.Fatalf("articles directory = %q", conf.Output.Articles.Directory)
+	}
+	if conf.Output.Articles.Filename != "index.md" {
+		t.Fatalf("articles filename = %q", conf.Output.Articles.Filename)
+	}
+	if conf.Output.Images.Directory != "static/images/%Y-%m-%d" {
+		t.Fatalf("images directory = %q", conf.Output.Images.Directory)
+	}
+	if conf.Output.Images.Filename != "[:id].png" {
+		t.Fatalf("images filename = %q", conf.Output.Images.Filename)
+	}
+	if conf.Output.Images.URL != "/images/%Y-%m-%d" {
+		t.Fatalf("images url = %q", conf.Output.Images.URL)
+	}
+}
+
+func TestConfigNormalize_PrefersOutputOverLegacyHugo(t *testing.T) {
+	conf := Config{
+		GitHub: NewGitHubConfig(),
+		Output: &OutputConfig{
+			Articles: &OutputArticlesConfig{
+				Directory: "content/custom",
+				Filename:  "custom.md",
+			},
+			Images: &OutputImagesConfig{
+				Directory: "static/custom",
+				Filename:  "custom.png",
+				URL:       "/custom",
+			},
+		},
+		Hugo: &HugoConfig{
+			Directory: &HugoDirectoryConfig{
+				Articles: "content/posts",
+				Images:   "static/images",
+			},
+			Filename: &HugoFilenameConfig{
+				Articles: "index.md",
+				Images:   "[:id].png",
+			},
+			Url: &HugoURLConfig{
+				Images: "/images",
+			},
+		},
+	}
+
+	conf.normalize()
+
+	if conf.Output.Articles.Directory != "content/custom" {
+		t.Fatalf("articles directory = %q", conf.Output.Articles.Directory)
+	}
+	if conf.Output.Articles.Filename != "custom.md" {
+		t.Fatalf("articles filename = %q", conf.Output.Articles.Filename)
+	}
+	if conf.Output.Images.Directory != "static/custom" {
+		t.Fatalf("images directory = %q", conf.Output.Images.Directory)
+	}
+	if conf.Output.Images.Filename != "custom.png" {
+		t.Fatalf("images filename = %q", conf.Output.Images.Filename)
+	}
+	if conf.Output.Images.URL != "/custom" {
+		t.Fatalf("images url = %q", conf.Output.Images.URL)
+	}
+}

--- a/pkg/config/type_test.go
+++ b/pkg/config/type_test.go
@@ -34,8 +34,8 @@ func TestConfigNormalize_LegacyHugoDirectoryFields(t *testing.T) {
 	if conf.Output.Images.Filename != "[:id].png" {
 		t.Fatalf("images filename = %q", conf.Output.Images.Filename)
 	}
-	if conf.Output.Images.URL != "/images/%Y-%m-%d" {
-		t.Fatalf("images url = %q", conf.Output.Images.URL)
+	if conf.Output.Images.URL() != "/images/%Y-%m-%d" {
+		t.Fatalf("images url = %q", conf.Output.Images.URL())
 	}
 }
 
@@ -50,7 +50,7 @@ func TestConfigNormalize_PrefersOutputOverLegacyHugo(t *testing.T) {
 			Images: &OutputImagesConfig{
 				Directory: "static/custom",
 				Filename:  "custom.png",
-				URL:       "/custom",
+				BaseURL:   Ptr("/custom"),
 			},
 		},
 		Hugo: &HugoConfig{
@@ -82,7 +82,51 @@ func TestConfigNormalize_PrefersOutputOverLegacyHugo(t *testing.T) {
 	if conf.Output.Images.Filename != "custom.png" {
 		t.Fatalf("images filename = %q", conf.Output.Images.Filename)
 	}
-	if conf.Output.Images.URL != "/custom" {
-		t.Fatalf("images url = %q", conf.Output.Images.URL)
+	if conf.Output.Images.URL() != "/custom" {
+		t.Fatalf("images url = %q", conf.Output.Images.URL())
+	}
+}
+
+func TestConfigNormalize_PreservesExplicitEmptyOutputImageURL(t *testing.T) {
+	conf := Config{
+		GitHub: NewGitHubConfig(),
+		Output: &OutputConfig{
+			Articles: &OutputArticlesConfig{},
+			Images: &OutputImagesConfig{
+				BaseURL: Ptr(""),
+			},
+		},
+		Hugo: &HugoConfig{
+			Url: &HugoURLConfig{
+				Images: "/images",
+			},
+		},
+	}
+
+	conf.normalize()
+
+	if conf.Output.Images.URL() != "" {
+		t.Fatalf("images url = %q", conf.Output.Images.URL())
+	}
+}
+
+func TestConfigNormalize_BackfillsMissingOutputImageURLFromLegacyHugo(t *testing.T) {
+	conf := Config{
+		GitHub: NewGitHubConfig(),
+		Output: &OutputConfig{
+			Articles: &OutputArticlesConfig{},
+			Images:   &OutputImagesConfig{},
+		},
+		Hugo: &HugoConfig{
+			Url: &HugoURLConfig{
+				Images: "/images",
+			},
+		},
+	}
+
+	conf.normalize()
+
+	if conf.Output.Images.URL() != "/images" {
+		t.Fatalf("images url = %q", conf.Output.Images.URL())
 	}
 }

--- a/pkg/config/util.go
+++ b/pkg/config/util.go
@@ -1,0 +1,5 @@
+package config
+
+func Ptr[T any](v T) *T {
+	return &v
+}

--- a/pkg/config/validation.go
+++ b/pkg/config/validation.go
@@ -26,12 +26,16 @@ func (c *Config) validate() error {
 }
 
 func (c *Config) WarnDeprecatedOptions() bool {
-	if c.Hugo.Url.AppendSlash {
+	if c.Hugo == nil {
+		return true
+	}
+	if c.Hugo.Url != nil && c.Hugo.Url.AppendSlash {
 		slog.Warn("hugo.url.appendSlash is deprecated. This option will be ignored.")
 	}
 	if c.Hugo.Bundle != "" {
 		slog.Warn("hugo.bundle is deprecated. This option will be ignored.")
 	}
+	slog.Warn("The 'hugo' config section is deprecated. Use 'output' instead.")
 
 	return true
 }

--- a/pkg/core/filesystem_articles.go
+++ b/pkg/core/filesystem_articles.go
@@ -96,28 +96,28 @@ func (r *FileSystemArticleRepository) Save(ctx context.Context, article *Article
 }
 
 func resolveArticleDirectory(conf config.Config, datetime time.Time) (string, error) {
-	dest := conf.Hugo.Directory.Articles
+	dest := conf.Output.Articles.Directory
 	if dest == "" {
-		return "", fmt.Errorf("hugo directory is not set")
+		return "", fmt.Errorf("output articles directory is not set")
 	}
 	return filepath.Clean(config.CompileTimeTemplate(datetime, dest)), nil
 }
 
 func resolveArticlePath(conf config.Config, datetime time.Time, directory string) (string, error) {
-	filename := conf.Hugo.Filename.Articles
+	filename := conf.Output.Articles.Filename
 	if filename == "" {
-		return "", fmt.Errorf("hugo filename is not set")
+		return "", fmt.Errorf("output articles filename is not set")
 	}
 	filename = config.CompileTimeTemplate(datetime, filename)
 	return filepath.Join(directory, filename), nil
 }
 
 func resolveImageOutput(conf config.Config, datetime time.Time) (string, string, error) {
-	imageDir := conf.Hugo.Directory.Images
+	imageDir := conf.Output.Images.Directory
 	if imageDir == "" {
-		return "", "", fmt.Errorf("hugo image directory is not set")
+		return "", "", fmt.Errorf("output images directory is not set")
 	}
-	imageURLBase := config.CompileTimeTemplate(datetime, conf.Hugo.Url.Images)
+	imageURLBase := config.CompileTimeTemplate(datetime, conf.Output.Images.URL)
 	return config.CompileTimeTemplate(datetime, imageDir), imageURLBase, nil
 }
 

--- a/pkg/core/filesystem_articles.go
+++ b/pkg/core/filesystem_articles.go
@@ -117,7 +117,7 @@ func resolveImageOutput(conf config.Config, datetime time.Time) (string, string,
 	if imageDir == "" {
 		return "", "", fmt.Errorf("output images directory is not set")
 	}
-	imageURLBase := config.CompileTimeTemplate(datetime, conf.Output.Images.URL)
+	imageURLBase := config.CompileTimeTemplate(datetime, conf.Output.Images.URL())
 	return config.CompileTimeTemplate(datetime, imageDir), imageURLBase, nil
 }
 

--- a/pkg/core/filesystem_articles_test.go
+++ b/pkg/core/filesystem_articles_test.go
@@ -30,10 +30,10 @@ func TestFileSystemArticleRepository_Save_RewritesImageURLs(t *testing.T) {
 	tempDir := t.TempDir()
 
 	conf := *config.NewConfig()
-	conf.Hugo.Directory.Articles = filepath.Join(tempDir, "content", "%Y-%m-%d")
-	conf.Hugo.Directory.Images = filepath.Join(tempDir, "static", "images", "%Y-%m-%d")
-	conf.Hugo.Url.Images = "/images/%Y-%m-%d"
-	conf.Hugo.Filename.Articles = "index.md"
+	conf.Output.Articles.Directory = filepath.Join(tempDir, "content", "%Y-%m-%d")
+	conf.Output.Images.Directory = filepath.Join(tempDir, "static", "images", "%Y-%m-%d")
+	conf.Output.Images.URL = "/images/%Y-%m-%d"
+	conf.Output.Articles.Filename = "index.md"
 
 	imageURL := "https://example.com/image.jpeg"
 	imageRepo := &fakeImageRepository{contentType: "image/jpeg", body: "jpeg"}

--- a/pkg/core/filesystem_articles_test.go
+++ b/pkg/core/filesystem_articles_test.go
@@ -32,7 +32,7 @@ func TestFileSystemArticleRepository_Save_RewritesImageURLs(t *testing.T) {
 	conf := *config.NewConfig()
 	conf.Output.Articles.Directory = filepath.Join(tempDir, "content", "%Y-%m-%d")
 	conf.Output.Images.Directory = filepath.Join(tempDir, "static", "images", "%Y-%m-%d")
-	conf.Output.Images.URL = "/images/%Y-%m-%d"
+	conf.Output.Images.BaseURL = Ptr("/images/%Y-%m-%d")
 	conf.Output.Articles.Filename = "index.md"
 
 	imageURL := "https://example.com/image.jpeg"

--- a/pkg/core/generator_test.go
+++ b/pkg/core/generator_test.go
@@ -32,8 +32,8 @@ func TestNewArticleGenerator(t *testing.T) {
 
 func TestArticleGenerator_ConvertIssueToArticle(t *testing.T) {
 	conf := *config.NewConfig()
-	conf.Hugo.Url.Images = "/images"
-	conf.Hugo.Filename.Images = "[:id].png"
+	conf.Output.Images.URL = "/images"
+	conf.Output.Images.Filename = "[:id].png"
 
 	gen, err := NewArticleGenerator(conf, "test-token")
 	assert.NoError(t, err)
@@ -77,10 +77,10 @@ func TestArticleGenerator_ConvertPullRequest(t *testing.T) {
 func TestArticleGenerator_SaveArticle(t *testing.T) {
 	tempDir := t.TempDir()
 	conf := *config.NewConfig()
-	conf.Hugo.Directory.Articles = tempDir + "/articles"
-	conf.Hugo.Directory.Images = tempDir + "/images"
-	conf.Hugo.Filename.Articles = "%Y-%m-%d.md"
-	conf.Hugo.Filename.Images = "[:id].png"
+	conf.Output.Articles.Directory = tempDir + "/articles"
+	conf.Output.Images.Directory = tempDir + "/images"
+	conf.Output.Articles.Filename = "%Y-%m-%d.md"
+	conf.Output.Images.Filename = "[:id].png"
 
 	gen, err := NewArticleGenerator(conf, "test-token")
 	assert.NoError(t, err)
@@ -179,10 +179,10 @@ func TestArticleGenerator_Generate(t *testing.T) {
 
 	tempDir := t.TempDir()
 	conf := *config.NewConfig()
-	conf.Hugo.Directory.Articles = tempDir + "/articles"
-	conf.Hugo.Directory.Images = tempDir + "/images"
-	conf.Hugo.Filename.Articles = "%Y-%m-%d.md"
-	conf.Hugo.Filename.Images = "[:id].png"
+	conf.Output.Articles.Directory = tempDir + "/articles"
+	conf.Output.Images.Directory = tempDir + "/images"
+	conf.Output.Articles.Filename = "%Y-%m-%d.md"
+	conf.Output.Images.Filename = "[:id].png"
 
 	// Create a mock IssueRepository.
 	issueRepo := newMockIssueRepository(server.URL)

--- a/pkg/core/generator_test.go
+++ b/pkg/core/generator_test.go
@@ -32,18 +32,18 @@ func TestNewArticleGenerator(t *testing.T) {
 
 func TestArticleGenerator_ConvertIssueToArticle(t *testing.T) {
 	conf := *config.NewConfig()
-	conf.Output.Images.URL = "/images"
+	conf.Output.Images.BaseURL = Ptr("/images")
 	conf.Output.Images.Filename = "[:id].png"
 
 	gen, err := NewArticleGenerator(conf, "test-token")
 	assert.NoError(t, err)
 
 	issue := &github.Issue{
-		Title:     generatorStringPtr("Test Issue"),
-		Body:      generatorStringPtr("Test content"),
+		Title:     Ptr("Test Issue"),
+		Body:      Ptr("Test content"),
 		CreatedAt: generatorParseTime("2021-01-01T00:00:00Z"),
-		User:      &github.User{Login: generatorStringPtr("testuser")},
-		State:     generatorStringPtr("closed"),
+		User:      &github.User{Login: Ptr("testuser")},
+		State:     Ptr("closed"),
 		Labels:    []*github.Label{},
 	}
 
@@ -61,11 +61,11 @@ func TestArticleGenerator_ConvertPullRequest(t *testing.T) {
 	assert.NoError(t, err)
 
 	pr := &github.Issue{
-		Title:            generatorStringPtr("PR Title"),
-		Body:             generatorStringPtr("PR content"),
+		Title:            Ptr("PR Title"),
+		Body:             Ptr("PR content"),
 		CreatedAt:        generatorParseTime("2021-01-01T00:00:00Z"),
-		User:             &github.User{Login: generatorStringPtr("user")},
-		State:            generatorStringPtr("open"),
+		User:             &github.User{Login: Ptr("user")},
+		State:            Ptr("open"),
 		Labels:           []*github.Label{},
 		PullRequestLinks: &github.PullRequestLinks{},
 	}
@@ -86,11 +86,11 @@ func TestArticleGenerator_SaveArticle(t *testing.T) {
 	assert.NoError(t, err)
 
 	issue := &github.Issue{
-		Title:     generatorStringPtr("Test Article"),
-		Body:      generatorStringPtr("Content"),
+		Title:     Ptr("Test Article"),
+		Body:      Ptr("Content"),
 		CreatedAt: generatorParseTime("2021-01-01T00:00:00Z"),
-		User:      &github.User{Login: generatorStringPtr("testuser")},
-		State:     generatorStringPtr("closed"),
+		User:      &github.User{Login: Ptr("testuser")},
+		State:     Ptr("closed"),
 		Labels:    []*github.Label{},
 	}
 
@@ -212,19 +212,19 @@ func TestArticleGenerator_Generate_ReturnsErrorWhenSaveFails(t *testing.T) {
 			issues: []*github.Issue{
 				{
 					Number:    github.Ptr(1),
-					Title:     generatorStringPtr("Issue 1"),
-					Body:      generatorStringPtr("Body 1"),
+					Title:     Ptr("Issue 1"),
+					Body:      Ptr("Body 1"),
 					CreatedAt: generatorParseTime("2021-01-01T00:00:00Z"),
-					User:      &github.User{Login: generatorStringPtr("user")},
-					State:     generatorStringPtr("closed"),
+					User:      &github.User{Login: Ptr("user")},
+					State:     Ptr("closed"),
 				},
 				{
 					Number:    github.Ptr(2),
-					Title:     generatorStringPtr("Issue 2"),
-					Body:      generatorStringPtr("Body 2"),
+					Title:     Ptr("Issue 2"),
+					Body:      Ptr("Body 2"),
 					CreatedAt: generatorParseTime("2021-01-02T00:00:00Z"),
-					User:      &github.User{Login: generatorStringPtr("user")},
-					State:     generatorStringPtr("closed"),
+					User:      &github.User{Login: Ptr("user")},
+					State:     Ptr("closed"),
 				},
 			},
 		},
@@ -249,10 +249,6 @@ func TestArticleGenerator_Generate_ReturnsErrorWhenSaveFails(t *testing.T) {
 }
 
 // Helper functions.
-
-func generatorStringPtr(s string) *string {
-	return &s
-}
 
 func generatorParseTime(s string) *github.Timestamp {
 	t, err := time.Parse(time.RFC3339, s)

--- a/pkg/core/issue_articles_test.go
+++ b/pkg/core/issue_articles_test.go
@@ -20,7 +20,7 @@ func TestNewArticleService(t *testing.T) {
 
 func TestArticleService_ConvertIssueToArticle(t *testing.T) {
 	conf := *config.NewConfig()
-	conf.Output.Images.URL = "/images/%Y-%m-%d"
+	conf.Output.Images.BaseURL = Ptr("/images/%Y-%m-%d")
 	conf.Output.Images.Filename = "[:id].png"
 
 	service := NewArticleService(conf)
@@ -33,11 +33,11 @@ func TestArticleService_ConvertIssueToArticle(t *testing.T) {
 		{
 			name: "基本的なIssue変換",
 			issue: &github.Issue{
-				Title:     stringPtr("Test Issue"),
-				Body:      stringPtr("Test body content"),
+				Title:     Ptr("Test Issue"),
+				Body:      Ptr("Test body content"),
 				CreatedAt: parseTime("2021-01-01T12:00:00Z"),
-				User:      &github.User{Login: stringPtr("testuser")},
-				State:     stringPtr("closed"),
+				User:      &github.User{Login: Ptr("testuser")},
+				State:     Ptr("closed"),
 				Labels:    []*github.Label{},
 			},
 			want: map[string]interface{}{
@@ -52,11 +52,11 @@ func TestArticleService_ConvertIssueToArticle(t *testing.T) {
 		{
 			name: "open状態のIssue（下書き）",
 			issue: &github.Issue{
-				Title:     stringPtr("Draft Issue"),
-				Body:      stringPtr("Draft content"),
+				Title:     Ptr("Draft Issue"),
+				Body:      Ptr("Draft content"),
 				CreatedAt: parseTime("2021-06-15T10:30:00Z"),
-				User:      &github.User{Login: stringPtr("author")},
-				State:     stringPtr("open"),
+				User:      &github.User{Login: Ptr("author")},
+				State:     Ptr("open"),
 				Labels:    []*github.Label{},
 			},
 			want: map[string]interface{}{
@@ -68,14 +68,14 @@ func TestArticleService_ConvertIssueToArticle(t *testing.T) {
 		{
 			name: "タグ付きIssue",
 			issue: &github.Issue{
-				Title:     stringPtr("Tagged Issue"),
-				Body:      stringPtr("Content"),
+				Title:     Ptr("Tagged Issue"),
+				Body:      Ptr("Content"),
 				CreatedAt: parseTime("2021-03-10T00:00:00Z"),
-				User:      &github.User{Login: stringPtr("user")},
-				State:     stringPtr("closed"),
+				User:      &github.User{Login: Ptr("user")},
+				State:     Ptr("closed"),
 				Labels: []*github.Label{
-					{Name: stringPtr("bug")},
-					{Name: stringPtr("enhancement")},
+					{Name: Ptr("bug")},
+					{Name: Ptr("enhancement")},
 				},
 			},
 			want: map[string]interface{}{
@@ -85,13 +85,13 @@ func TestArticleService_ConvertIssueToArticle(t *testing.T) {
 		{
 			name: "マイルストーン付きIssue",
 			issue: &github.Issue{
-				Title:     stringPtr("Milestone Issue"),
-				Body:      stringPtr("Content"),
+				Title:     Ptr("Milestone Issue"),
+				Body:      Ptr("Content"),
 				CreatedAt: parseTime("2021-05-01T00:00:00Z"),
-				User:      &github.User{Login: stringPtr("user")},
-				State:     stringPtr("closed"),
+				User:      &github.User{Login: Ptr("user")},
+				State:     Ptr("closed"),
 				Labels:    []*github.Label{},
-				Milestone: &github.Milestone{Title: stringPtr("v1.0")},
+				Milestone: &github.Milestone{Title: Ptr("v1.0")},
 			},
 			want: map[string]interface{}{
 				"category": "v1.0",
@@ -100,11 +100,11 @@ func TestArticleService_ConvertIssueToArticle(t *testing.T) {
 		{
 			name: "フロントマター付きIssue",
 			issue: &github.Issue{
-				Title:     stringPtr("FrontMatter Issue"),
-				Body:      stringPtr("```\nauthor: Custom Author\ncustom: value\n```\n\nContent here"),
+				Title:     Ptr("FrontMatter Issue"),
+				Body:      Ptr("```\nauthor: Custom Author\ncustom: value\n```\n\nContent here"),
 				CreatedAt: parseTime("2021-02-01T00:00:00Z"),
-				User:      &github.User{Login: stringPtr("user")},
-				State:     stringPtr("closed"),
+				User:      &github.User{Login: Ptr("user")},
+				State:     Ptr("closed"),
 				Labels:    []*github.Label{},
 			},
 			want: map[string]interface{}{
@@ -115,11 +115,11 @@ func TestArticleService_ConvertIssueToArticle(t *testing.T) {
 		{
 			name: "YAML front matter issue",
 			issue: &github.Issue{
-				Title:     stringPtr("YAML FrontMatter Issue"),
-				Body:      stringPtr("---\nauthor: YAML Author\ncustom: value\n---\n\nContent here"),
+				Title:     Ptr("YAML FrontMatter Issue"),
+				Body:      Ptr("---\nauthor: YAML Author\ncustom: value\n---\n\nContent here"),
 				CreatedAt: parseTime("2021-02-01T00:00:00Z"),
-				User:      &github.User{Login: stringPtr("user")},
-				State:     stringPtr("closed"),
+				User:      &github.User{Login: Ptr("user")},
+				State:     Ptr("closed"),
 				Labels:    []*github.Label{},
 			},
 			want: map[string]interface{}{
@@ -130,11 +130,11 @@ func TestArticleService_ConvertIssueToArticle(t *testing.T) {
 		{
 			name: "TOML front matter issue",
 			issue: &github.Issue{
-				Title:     stringPtr("TOML FrontMatter Issue"),
-				Body:      stringPtr("+++\nauthor = \"TOML Author\"\ncustom = \"value\"\n+++\n\nContent here"),
+				Title:     Ptr("TOML FrontMatter Issue"),
+				Body:      Ptr("+++\nauthor = \"TOML Author\"\ncustom = \"value\"\n+++\n\nContent here"),
 				CreatedAt: parseTime("2021-02-01T00:00:00Z"),
-				User:      &github.User{Login: stringPtr("user")},
-				State:     stringPtr("closed"),
+				User:      &github.User{Login: Ptr("user")},
+				State:     Ptr("closed"),
 				Labels:    []*github.Label{},
 			},
 			want: map[string]interface{}{
@@ -145,11 +145,11 @@ func TestArticleService_ConvertIssueToArticle(t *testing.T) {
 		{
 			name: "Markdown画像付きIssue",
 			issue: &github.Issue{
-				Title:     stringPtr("Image Issue"),
-				Body:      stringPtr("![image](https://example.com/image1.png)\n\n![image](https://example.com/image2.png)"),
+				Title:     Ptr("Image Issue"),
+				Body:      Ptr("![image](https://example.com/image1.png)\n\n![image](https://example.com/image2.png)"),
 				CreatedAt: parseTime("2021-04-01T15:00:00Z"),
-				User:      &github.User{Login: stringPtr("user")},
-				State:     stringPtr("closed"),
+				User:      &github.User{Login: Ptr("user")},
+				State:     Ptr("closed"),
 				Labels:    []*github.Label{},
 			},
 			want: map[string]interface{}{
@@ -159,11 +159,11 @@ func TestArticleService_ConvertIssueToArticle(t *testing.T) {
 		{
 			name: "HTML画像付きIssue",
 			issue: &github.Issue{
-				Title:     stringPtr("HTML Image Issue"),
-				Body:      stringPtr(`<img width="100" alt="test" src="https://example.com/test.png">`),
+				Title:     Ptr("HTML Image Issue"),
+				Body:      Ptr(`<img width="100" alt="test" src="https://example.com/test.png">`),
 				CreatedAt: parseTime("2021-07-01T00:00:00Z"),
-				User:      &github.User{Login: stringPtr("user")},
-				State:     stringPtr("closed"),
+				User:      &github.User{Login: Ptr("user")},
+				State:     Ptr("closed"),
 				Labels:    []*github.Label{},
 			},
 			want: map[string]interface{}{
@@ -216,11 +216,11 @@ func TestArticleService_ConvertIssueToArticle_PullRequest(t *testing.T) {
 	service := NewArticleService(*config.NewConfig())
 
 	pr := &github.Issue{
-		Title:            stringPtr("PR Title"),
-		Body:             stringPtr("PR body"),
+		Title:            Ptr("PR Title"),
+		Body:             Ptr("PR body"),
 		CreatedAt:        parseTime("2021-01-01T00:00:00Z"),
-		User:             &github.User{Login: stringPtr("user")},
-		State:            stringPtr("open"),
+		User:             &github.User{Login: Ptr("user")},
+		State:            Ptr("open"),
 		Labels:           []*github.Label{},
 		PullRequestLinks: &github.PullRequestLinks{},
 	}
@@ -233,11 +233,11 @@ func TestArticleService_ConvertIssueToArticle_CRRemoval(t *testing.T) {
 	service := NewArticleService(*config.NewConfig())
 
 	issue := &github.Issue{
-		Title:     stringPtr("Test"),
-		Body:      stringPtr("Line1\r\nLine2\r\nLine3"),
+		Title:     Ptr("Test"),
+		Body:      Ptr("Line1\r\nLine2\r\nLine3"),
 		CreatedAt: parseTime("2021-01-01T00:00:00Z"),
-		User:      &github.User{Login: stringPtr("user")},
-		State:     stringPtr("closed"),
+		User:      &github.User{Login: Ptr("user")},
+		State:     Ptr("closed"),
 		Labels:    []*github.Label{},
 	}
 
@@ -306,10 +306,6 @@ func TestMetadataParser_Parse(t *testing.T) {
 			assertEqualCmp(t, tt.wantParsed, block.Values.Values())
 		})
 	}
-}
-
-func stringPtr(s string) *string {
-	return &s
 }
 
 func parseTime(s string) *github.Timestamp {

--- a/pkg/core/issue_articles_test.go
+++ b/pkg/core/issue_articles_test.go
@@ -20,8 +20,8 @@ func TestNewArticleService(t *testing.T) {
 
 func TestArticleService_ConvertIssueToArticle(t *testing.T) {
 	conf := *config.NewConfig()
-	conf.Hugo.Url.Images = "/images/%Y-%m-%d"
-	conf.Hugo.Filename.Images = "[:id].png"
+	conf.Output.Images.URL = "/images/%Y-%m-%d"
+	conf.Output.Images.Filename = "[:id].png"
 
 	service := NewArticleService(conf)
 

--- a/pkg/core/util.go
+++ b/pkg/core/util.go
@@ -1,0 +1,15 @@
+package core
+
+// Use this file only as a last resort for helpers that are genuinely shared
+// and hard to classify elsewhere.
+//
+// Prefer keeping functions close to the domain that owns them. Helpers added
+// here should usually be small compatibility shims that can be replaced by
+// standard library features when the project can adopt them. Ptr is one such
+// example: it can be replaced in the future when moving to a Go 1.26-friendly
+// approach, but for now it lives here as a temporary shared helper.
+
+// Ptr returns a pointer to the given value.
+func Ptr[T any](v T) *T {
+	return &v
+}


### PR DESCRIPTION
## Summary

This PR updates the configuration schema to better reflect the current responsibility of the tool.

- introduce `output` as the canonical config section
- rename config references from the legacy `hugo`-oriented structure to `output.articles` / `output.images`
- keep legacy `hugo` config readable for backward compatibility in `v1.0.0`
- add a `migrate` command to rewrite existing config files to the latest schema
- update README and docs to use the new config structure

## Motivation

The existing `hugo` config name no longer matches the actual role of the application.

The tool is no longer tied to Hugo-specific usage. The config is really about output paths and naming rules, so `output` is a more accurate and extensible structure.

## Backward Compatibility

- existing `hugo` config is still supported for reading
- newly generated and migrated config uses the `output` schema
- legacy `hugo` keys are now treated as deprecated and intended for future removal

## Example

Before:

```yaml
hugo:
  directory:
    articles: content/posts
    images: static/images/%Y-%m-%d_%H%M%S
  filename:
    articles: "%Y-%m-%d_%H%M%S.md"
    images: "[:id].png"
  url:
    images: /images/%Y-%m-%d_%H%M%S
```

After:

```yaml
output:
  articles:
    directory: content/posts
    filename: "%Y-%m-%d_%H%M%S.md"
  images:
    directory: static/images/%Y-%m-%d_%H%M%S
    filename: "[:id].png"
    url: /images/%Y-%m-%d_%H%M%S
```

## Validation

- updated CLI/config tests
- verified backward-compatible config normalization
- verified targeted core tests for output path resolution and article generation behavior
