### PR TITLE
docs: refresh documentation for v1.0.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Issues are treated as articles.
 
 ## Prerequisites
 
-- Go
+- Go 1.25.0 or higher
 - GitHub Token
 
 ## Installation
@@ -14,7 +14,7 @@ Issues are treated as articles.
 ### 1. Install this application
 
 ```bash
-$ go install github.com/rokuosan/github-issue-cms@v0.6.1
+$ go install github.com/rokuosan/github-issue-cms@v1.0.0
 ```
 
 GitHub Releases also publish prebuilt binaries for macOS, Linux, and Windows.
@@ -58,13 +58,13 @@ $ tree --dirsfirst
 .
 ├── content
 │   └── posts
-│       ├── 2004501283.md
-│       └── 2006779255.md
+│       ├── 2026-04-30_120000.md
+│       └── 2026-04-30_121500.md
 ├── static
 │   └── images
-│       ├── 2004501283
+│       ├── 2026-04-30_120000
 │       │   └── 0.png
-│       └── 2006779255
+│       └── 2026-04-30_121500
 │           ├── 0.png
 │           ├── 1.png
 │           └── 2.png
@@ -104,7 +104,7 @@ jobs:
         # go-version-file: go.mod
 
     - name: Install
-      run: go install github.com/rokuosan/github-issue-cms@v0.6.1
+      run: go install github.com/rokuosan/github-issue-cms@v1.0.0
 
     - name: Generate
       run: github-issue-cms generate --token=${{ secrets.GITHUB_TOKEN }}
@@ -118,30 +118,3 @@ jobs:
 Congratulations.
 
 Your Hugo site content will be regenerated and committed automatically when you push to `main` or an issue is closed or reopened.
-
-## Release automation
-
-This repository publishes CLI binaries to GitHub Releases automatically when a tag matching `v*` is pushed.
-
-Artifacts:
-
-- `github-issue-cms_<version>_darwin_amd64.tar.gz`
-- `github-issue-cms_<version>_darwin_arm64.tar.gz`
-- `github-issue-cms_<version>_linux_amd64.tar.gz`
-- `github-issue-cms_<version>_linux_arm64.tar.gz`
-- `github-issue-cms_<version>_windows_amd64.zip`
-- `checksums.txt`
-
-Release flow:
-
-```bash
-git tag v0.6.2
-git push origin v0.6.2
-```
-
-For local validation:
-
-```bash
-task release:check
-task release:snapshot
-```

--- a/docs/content/configuration/github-actions-integration.ja.md
+++ b/docs/content/configuration/github-actions-integration.ja.md
@@ -40,7 +40,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version-file: go.mod
+          go-version: '1.25.0'
 
       - name: Install github-issue-cms
         run: go install github.com/rokuosan/github-issue-cms@v1.0.0
@@ -59,4 +59,5 @@ jobs:
 - 生成ファイルをリポジトリへコミットするために `contents: write` が必要です。
 - GitHub API で Issue を読むために `issues: read` が必要です。
 - `gic.config.yaml` をリポジトリルートに置く構成であれば、追加設定は不要です。
+- リポジトリが Go module で、ルートに `go.mod` がある場合は `go-version` の代わりに `go-version-file: go.mod` を利用できます。
 - Actions のログを増やしたい場合は `github-issue-cms -v generate --token=...` を利用してください。

--- a/docs/content/configuration/github-actions-integration.ja.md
+++ b/docs/content/configuration/github-actions-integration.ja.md
@@ -4,6 +4,59 @@ date: 2021-12-25
 weight: 2
 ---
 
-{{< callout type="info" >}}
-現在執筆中です。
-{{< /callout >}}
+このページでは GitHub Actions を使ってコンテンツを自動生成する方法を説明します。
+
+## 概要
+
+`github-issue-cms` は GitHub Actions の組み込み `GITHUB_TOKEN` で実行できます。
+
+以下のワークフローでは、次の場合に Markdown を再生成します。
+
+- `main` への push
+- Issue の reopen
+- Issue の close
+
+## ワークフロー例
+
+```yaml
+name: Generate content from GitHub Issues
+
+on:
+  push:
+    branches: [ "main" ]
+  issues:
+    types: [reopened, closed]
+
+permissions:
+  contents: write
+  issues: read
+
+jobs:
+  generate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: go.mod
+
+      - name: Install github-issue-cms
+        run: go install github.com/rokuosan/github-issue-cms@v1.0.0
+
+      - name: Generate content
+        run: github-issue-cms generate --token=${{ secrets.GITHUB_TOKEN }}
+
+      - name: Commit generated files
+        uses: stefanzweifel/git-auto-commit-action@04702edda442b2e678b25b537cec683a1493fcb9 # v7.1.0
+        with:
+          commit_message: "ci(github-issue-cms): update content from GitHub Issues"
+```
+
+## 補足
+
+- 生成ファイルをリポジトリへコミットするために `contents: write` が必要です。
+- GitHub API で Issue を読むために `issues: read` が必要です。
+- `gic.config.yaml` をリポジトリルートに置く構成であれば、追加設定は不要です。
+- Actions のログを増やしたい場合は `github-issue-cms -v generate --token=...` を利用してください。

--- a/docs/content/configuration/github-actions-integration.md
+++ b/docs/content/configuration/github-actions-integration.md
@@ -40,7 +40,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version-file: go.mod
+          go-version: '1.25.0'
 
       - name: Install github-issue-cms
         run: go install github.com/rokuosan/github-issue-cms@v1.0.0
@@ -59,4 +59,5 @@ jobs:
 - `contents: write` is required to commit generated files back to the repository.
 - `issues: read` is required to read issues through the GitHub API.
 - If you keep `gic.config.yaml` in the repository root, no extra setup is required.
+- If your repository is a Go module and has a root `go.mod`, you can replace `go-version` with `go-version-file: go.mod`.
 - Use `github-issue-cms -v generate --token=...` if you want more logs in the Actions output.

--- a/docs/content/configuration/github-actions-integration.md
+++ b/docs/content/configuration/github-actions-integration.md
@@ -4,6 +4,59 @@ date: 2021-12-25
 weight: 2
 ---
 
-{{< callout type="info" >}}
-Currently under development.
-{{< /callout >}}
+This page explains how to regenerate content automatically with GitHub Actions.
+
+## Overview
+
+`github-issue-cms` can run in GitHub Actions with the built-in `GITHUB_TOKEN`.
+
+The workflow below regenerates Markdown files when:
+
+- you push to `main`
+- an issue is reopened
+- an issue is closed
+
+## Example Workflow
+
+```yaml
+name: Generate content from GitHub Issues
+
+on:
+  push:
+    branches: [ "main" ]
+  issues:
+    types: [reopened, closed]
+
+permissions:
+  contents: write
+  issues: read
+
+jobs:
+  generate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: go.mod
+
+      - name: Install github-issue-cms
+        run: go install github.com/rokuosan/github-issue-cms@v1.0.0
+
+      - name: Generate content
+        run: github-issue-cms generate --token=${{ secrets.GITHUB_TOKEN }}
+
+      - name: Commit generated files
+        uses: stefanzweifel/git-auto-commit-action@04702edda442b2e678b25b537cec683a1493fcb9 # v7.1.0
+        with:
+          commit_message: "ci(github-issue-cms): update content from GitHub Issues"
+```
+
+## Notes
+
+- `contents: write` is required to commit generated files back to the repository.
+- `issues: read` is required to read issues through the GitHub API.
+- If you keep `gic.config.yaml` in the repository root, no extra setup is required.
+- Use `github-issue-cms -v generate --token=...` if you want more logs in the Actions output.

--- a/docs/content/quickstart.ja.md
+++ b/docs/content/quickstart.ja.md
@@ -10,8 +10,8 @@ weight: 1
 
 以下のものを利用します。事前に準備しておいてください。
 
-- Go v1.22.1 (or higher)
-- Hugo extended
+- Go 1.25.0 以上
+- Issues が有効な GitHub リポジトリ
 - GitHub Access Token
 
 ## 手順
@@ -23,7 +23,7 @@ weight: 1
 以下のコマンドを実行します。
 
 ```shell
-$ go install github.com/rokuosan/github-issue-cms@v0.6.1
+$ go install github.com/rokuosan/github-issue-cms@v1.0.0
 ```
 
 ### 2. コンフィグの作成
@@ -53,7 +53,7 @@ output:
 以下のコマンドを実行して、対象のリポジトリからすべてのIssueをMarkdownに変換します。
 
 ```shell
-$ github-issue-cms generate --token="<YOUR_GITHUB_ACCESS_TOKEN>" -d
+$ github-issue-cms generate --token="<YOUR_GITHUB_ACCESS_TOKEN>"
 ```
 
 もし、Issueに添付画像がある場合は以下のように出力されます。
@@ -77,6 +77,8 @@ $ tree --dirsfirst
 ```
 
 出力されるファイルやディレクトリは、``gic.config.yaml``で変更することができます。
+
+詳細ログを出したい場合は `-v`、デバッグログを出したい場合は `-vv` を利用してください。
 
 ``gic.config.yaml``の設定については、[gic.config.yaml の設定](../configuration/parameters)を参照してください。
 

--- a/docs/content/quickstart.md
+++ b/docs/content/quickstart.md
@@ -10,8 +10,8 @@ This page explains how to get started with GitHub Issue CMS.
 
 The following are required. Please prepare them in advance.
 
-- Go v1.22.1 (or higher)
-- Hugo extended
+- Go 1.25.0 or higher
+- GitHub repository with Issues enabled
 - GitHub Access Token
 
 ## Steps
@@ -23,7 +23,7 @@ The following are required. Please prepare them in advance.
 Run the following command:
 
 ```shell
-$ go install github.com/rokuosan/github-issue-cms@v0.6.1
+$ go install github.com/rokuosan/github-issue-cms@v1.0.0
 ```
 
 ### 2. Create configuration file
@@ -53,7 +53,7 @@ output:
 Run the following command to convert all issues from the target repository to Markdown:
 
 ```shell
-$ github-issue-cms generate --token="<YOUR_GITHUB_ACCESS_TOKEN>" -d
+$ github-issue-cms generate --token="<YOUR_GITHUB_ACCESS_TOKEN>"
 ```
 
 If issues have attached images, the output will be as follows:
@@ -77,6 +77,8 @@ $ tree --dirsfirst
 ```
 
 The output files and directories can be changed in ``gic.config.yaml``.
+
+If you want verbose logs, use `-v`. For debug logs, use `-vv`.
 
 For more information about ``gic.config.yaml`` settings, please refer to [gic.config.yaml Configuration](../configuration/parameters).
 


### PR DESCRIPTION
## Summary

- refresh README and quickstart docs for the `v1.0.0` release
- update install and release examples from `v0.x` to `v1.0.0`
- fix CLI examples to match current behavior, including removal of the invalid `generate -d` example
- align prerequisites and output examples with the current implementation
- replace the placeholder GitHub Actions docs with a complete workflow example in English and Japanese

## Verification

- `go test ./...`
- `go run . --help`
- `go run . version`
- `task release:check`
- `task release:snapshot`
- verified `init` generates canonical `output:` config
- verified `migrate` rewrites legacy `hugo:` config to `output:`
