### PR TITLE
feat: support filtering issues by label

### DIFF
--- a/docs/content/configuration/parameters.ja.md
+++ b/docs/content/configuration/parameters.ja.md
@@ -14,6 +14,8 @@ weight: 1
 github:
   username: 'rokuosan'
   repository: 'github-issue-cms'
+  labels:
+    - 'article'
 
 output:
   articles:
@@ -33,6 +35,7 @@ GitHub の設定です。
 
 - `username`: GitHub のユーザー名
 - `repository`: Issue を取得するリポジトリ名
+- `labels`: 指定したラベルをすべて持つ Issue のみ取得
 
 ### `output`
 

--- a/docs/content/configuration/parameters.md
+++ b/docs/content/configuration/parameters.md
@@ -14,6 +14,8 @@ This page explains the configuration of `gic.config.yaml`.
 github:
   username: 'rokuosan'
   repository: 'github-issue-cms'
+  labels:
+    - 'article'
 
 output:
   articles:
@@ -33,6 +35,7 @@ GitHub settings.
 
 - `username`: GitHub username
 - `repository`: Repository name to fetch issues from
+- `labels`: Only fetch issues that have all specified labels
 
 ### `output`
 

--- a/pkg/config/type.go
+++ b/pkg/config/type.go
@@ -10,8 +10,8 @@ type Config struct {
 }
 
 type GitHubConfig struct {
-	Username   string `yaml:"username" mapstructure:"username"`
-	Repository string `yaml:"repository" mapstructure:"repository"`
+	Username   string   `yaml:"username" mapstructure:"username"`
+	Repository string   `yaml:"repository" mapstructure:"repository"`
 	Labels     []string `yaml:"labels,omitempty" mapstructure:"labels"`
 }
 

--- a/pkg/config/type.go
+++ b/pkg/config/type.go
@@ -12,6 +12,7 @@ type Config struct {
 type GitHubConfig struct {
 	Username   string `yaml:"username" mapstructure:"username"`
 	Repository string `yaml:"repository" mapstructure:"repository"`
+	Labels     []string `yaml:"labels,omitempty" mapstructure:"labels"`
 }
 
 type OutputConfig struct {
@@ -80,6 +81,7 @@ func NewGitHubConfig() *GitHubConfig {
 	return &GitHubConfig{
 		Username:   "<YOUR_USERNAME>",
 		Repository: "<YOUR_REPOSITORY>",
+		Labels:     nil,
 	}
 }
 

--- a/pkg/core/generator.go
+++ b/pkg/core/generator.go
@@ -10,8 +10,14 @@ import (
 	"github.com/rokuosan/github-issue-cms/pkg/config"
 )
 
+type IssueListQuery struct {
+	Username   string
+	Repository string
+	Labels     []string
+}
+
 type IssueStore interface {
-	ListIssues(ctx context.Context, username, repository string) ([]*github.Issue, error)
+	ListIssues(ctx context.Context, query IssueListQuery) ([]*github.Issue, error)
 }
 
 type ArticleStore interface {
@@ -57,7 +63,11 @@ func NewArticleGeneratorWithLogger(conf config.Config, token string, logger *slo
 
 // GetIssues retrieves all issues from the specified repository.
 func (g *ArticleGenerator) GetIssues(ctx context.Context, username, repository string) ([]*github.Issue, error) {
-	return g.issueRepo.ListIssues(ctx, username, repository)
+	return g.issueRepo.ListIssues(ctx, IssueListQuery{
+		Username:   username,
+		Repository: repository,
+		Labels:     g.config.GitHub.Labels,
+	})
 }
 
 // ConvertIssueToArticle converts an issue into an Article entity.

--- a/pkg/core/generator.go
+++ b/pkg/core/generator.go
@@ -63,10 +63,15 @@ func NewArticleGeneratorWithLogger(conf config.Config, token string, logger *slo
 
 // GetIssues retrieves all issues from the specified repository.
 func (g *ArticleGenerator) GetIssues(ctx context.Context, username, repository string) ([]*github.Issue, error) {
+	var labels []string
+	if g.config.GitHub != nil {
+		labels = g.config.GitHub.Labels
+	}
+
 	return g.issueRepo.ListIssues(ctx, IssueListQuery{
 		Username:   username,
 		Repository: repository,
-		Labels:     g.config.GitHub.Labels,
+		Labels:     labels,
 	})
 }
 

--- a/pkg/core/generator_test.go
+++ b/pkg/core/generator_test.go
@@ -154,6 +154,29 @@ func TestArticleGenerator_GetIssues(t *testing.T) {
 	assertEqualCmp(t, []string{"Test Issue 1", "Test Issue 2"}, []string{issues[0].GetTitle(), issues[1].GetTitle()})
 }
 
+func TestArticleGenerator_GetIssues_WithNilGitHubConfig(t *testing.T) {
+	conf := config.Config{}
+	issueRepo := &stubIssueStore{
+		issues: []*github.Issue{
+			{Title: Ptr("Test Issue")},
+		},
+	}
+
+	gen := &ArticleGenerator{
+		issueRepo: issueRepo,
+		service:   NewArticleService(conf),
+		config:    conf,
+		logger:    slog.Default(),
+	}
+
+	issues, err := gen.GetIssues(context.Background(), "testuser", "testrepo")
+	assert.NoError(t, err)
+	assert.Len(t, issues, 1)
+	assert.Nil(t, issueRepo.lastQuery.Labels)
+	assertEqualCmp(t, "testuser", issueRepo.lastQuery.Username)
+	assertEqualCmp(t, "testrepo", issueRepo.lastQuery.Repository)
+}
+
 func TestArticleGenerator_Generate(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/api/v3/repos/testuser/testrepo/issues" {
@@ -278,7 +301,7 @@ func (m *mockIssueRepository) ListIssues(ctx context.Context, query IssueListQue
 	}
 
 	opts := &github.IssueListByRepoOptions{
-		State: "all",
+		State:  "all",
 		Labels: query.Labels,
 		ListOptions: github.ListOptions{
 			PerPage: 100,
@@ -309,11 +332,13 @@ func (m *mockIssueRepository) ListIssues(ctx context.Context, query IssueListQue
 }
 
 type stubIssueStore struct {
-	issues []*github.Issue
-	err    error
+	issues    []*github.Issue
+	err       error
+	lastQuery IssueListQuery
 }
 
 func (s *stubIssueStore) ListIssues(ctx context.Context, query IssueListQuery) ([]*github.Issue, error) {
+	s.lastQuery = query
 	return s.issues, s.err
 }
 

--- a/pkg/core/generator_test.go
+++ b/pkg/core/generator_test.go
@@ -272,13 +272,14 @@ type mockIssueRepository struct {
 	client *github.Client
 }
 
-func (m *mockIssueRepository) ListIssues(ctx context.Context, username, repository string) ([]*github.Issue, error) {
-	if username == "" || repository == "" {
+func (m *mockIssueRepository) ListIssues(ctx context.Context, query IssueListQuery) ([]*github.Issue, error) {
+	if query.Username == "" || query.Repository == "" {
 		return nil, fmt.Errorf("username and repository name are required")
 	}
 
 	opts := &github.IssueListByRepoOptions{
 		State: "all",
+		Labels: query.Labels,
 		ListOptions: github.ListOptions{
 			PerPage: 100,
 		},
@@ -286,7 +287,7 @@ func (m *mockIssueRepository) ListIssues(ctx context.Context, username, reposito
 
 	var allIssues []*github.Issue
 	for {
-		issues, resp, err := m.client.Issues.ListByRepo(ctx, username, repository, opts)
+		issues, resp, err := m.client.Issues.ListByRepo(ctx, query.Username, query.Repository, opts)
 		if err != nil {
 			return nil, err
 		}
@@ -312,7 +313,7 @@ type stubIssueStore struct {
 	err    error
 }
 
-func (s *stubIssueStore) ListIssues(ctx context.Context, username, repository string) ([]*github.Issue, error) {
+func (s *stubIssueStore) ListIssues(ctx context.Context, query IssueListQuery) ([]*github.Issue, error) {
 	return s.issues, s.err
 }
 

--- a/pkg/core/github_issues.go
+++ b/pkg/core/github_issues.go
@@ -78,7 +78,7 @@ func (r *GitHubIssueRepository) listIssuesPage(ctx context.Context, query IssueL
 		query.Username,
 		query.Repository,
 		&github.IssueListByRepoOptions{
-			State: "all",
+			State:  "all",
 			Labels: query.Labels,
 			ListOptions: github.ListOptions{
 				PerPage: 100,

--- a/pkg/core/github_issues.go
+++ b/pkg/core/github_issues.go
@@ -39,8 +39,8 @@ func NewGitHubIssueRepositoryWithLogger(token string, logger *slog.Logger) (Issu
 }
 
 // ListIssues retrieves all issues from the specified repository.
-func (r *GitHubIssueRepository) ListIssues(ctx context.Context, username, repoName string) ([]*github.Issue, error) {
-	if username == "" || repoName == "" {
+func (r *GitHubIssueRepository) ListIssues(ctx context.Context, query IssueListQuery) ([]*github.Issue, error) {
+	if query.Username == "" || query.Repository == "" {
 		return nil, fmt.Errorf("username and repository name are required")
 	}
 
@@ -55,7 +55,7 @@ func (r *GitHubIssueRepository) ListIssues(ctx context.Context, username, repoNa
 		if err := ctx.Err(); err != nil {
 			return nil, err
 		}
-		issuesAndPRs, resp, err := r.listIssuesPage(ctx, username, repoName, page)
+		issuesAndPRs, resp, err := r.listIssuesPage(ctx, query, page)
 
 		if err != nil {
 			return nil, normalizeGitHubIssueError(err)
@@ -72,13 +72,14 @@ func (r *GitHubIssueRepository) ListIssues(ctx context.Context, username, repoNa
 	return issues, nil
 }
 
-func (r *GitHubIssueRepository) listIssuesPage(ctx context.Context, username, repoName string, page int) ([]*github.Issue, *github.Response, error) {
+func (r *GitHubIssueRepository) listIssuesPage(ctx context.Context, query IssueListQuery, page int) ([]*github.Issue, *github.Response, error) {
 	return r.client.Issues.ListByRepo(
 		ctx,
-		username,
-		repoName,
+		query.Username,
+		query.Repository,
 		&github.IssueListByRepoOptions{
 			State: "all",
+			Labels: query.Labels,
 			ListOptions: github.ListOptions{
 				PerPage: 100,
 				Page:    page,

--- a/pkg/core/github_issues_test.go
+++ b/pkg/core/github_issues_test.go
@@ -81,7 +81,7 @@ func TestGitHubIssueRepository_ListIssues(t *testing.T) {
 		assert.NoError(t, err)
 		repo := &GitHubIssueRepository{client: client, logger: slog.Default()}
 
-		issues, err := repo.ListIssues(context.Background(), "testuser", "testrepo")
+		issues, err := repo.ListIssues(context.Background(), IssueListQuery{Username: "testuser", Repository: "testrepo"})
 		assert.NoError(t, err)
 		assert.NotNil(t, issues)
 		assertEqualCmp(t, []string{"Test Issue 1", "Test Issue 2"}, []string{issues[0].GetTitle(), issues[1].GetTitle()})
@@ -91,7 +91,7 @@ func TestGitHubIssueRepository_ListIssues(t *testing.T) {
 		client := github.NewClient(nil)
 		repo := &GitHubIssueRepository{client: client, logger: slog.Default()}
 
-		issues, err := repo.ListIssues(context.Background(), "", "testrepo")
+		issues, err := repo.ListIssues(context.Background(), IssueListQuery{Repository: "testrepo"})
 		assert.Error(t, err)
 		assert.Nil(t, issues)
 		assert.Contains(t, err.Error(), "username and repository name are required")
@@ -101,7 +101,7 @@ func TestGitHubIssueRepository_ListIssues(t *testing.T) {
 		client := github.NewClient(nil)
 		repo := &GitHubIssueRepository{client: client, logger: slog.Default()}
 
-		issues, err := repo.ListIssues(context.Background(), "testuser", "")
+		issues, err := repo.ListIssues(context.Background(), IssueListQuery{Username: "testuser"})
 		assert.Error(t, err)
 		assert.Nil(t, issues)
 		assert.Contains(t, err.Error(), "username and repository name are required")
@@ -157,7 +157,7 @@ func TestGitHubIssueRepository_ListIssues_FiltersPRs(t *testing.T) {
 	assert.NoError(t, err)
 	repo := &GitHubIssueRepository{client: client, logger: slog.Default()}
 
-	issues, err := repo.ListIssues(context.Background(), "testuser", "testrepo")
+	issues, err := repo.ListIssues(context.Background(), IssueListQuery{Username: "testuser", Repository: "testrepo"})
 	assert.NoError(t, err)
 	assert.NotNil(t, issues)
 	assertEqualCmp(t, []string{"Real Issue", "Another Issue"}, []string{issues[0].GetTitle(), issues[1].GetTitle()})
@@ -207,7 +207,7 @@ func TestGitHubIssueRepository_ListIssues_Pagination(t *testing.T) {
 	assert.NoError(t, err)
 	repo := &GitHubIssueRepository{client: client, logger: slog.Default()}
 
-	issues, err := repo.ListIssues(context.Background(), "testuser", "testrepo")
+	issues, err := repo.ListIssues(context.Background(), IssueListQuery{Username: "testuser", Repository: "testrepo"})
 	assert.NoError(t, err)
 	assert.NotNil(t, issues)
 	assertEqualCmp(t, []string{"Issue 1", "Issue 2"}, []string{issues[0].GetTitle(), issues[1].GetTitle()})
@@ -227,7 +227,7 @@ func TestGitHubIssueRepository_ListIssues_InvalidCredentials(t *testing.T) {
 	assert.NoError(t, err)
 	repo := &GitHubIssueRepository{client: client, logger: slog.Default()}
 
-	issues, err := repo.ListIssues(context.Background(), "testuser", "testrepo")
+	issues, err := repo.ListIssues(context.Background(), IssueListQuery{Username: "testuser", Repository: "testrepo"})
 	assert.Error(t, err)
 	assert.Nil(t, issues)
 	assert.Contains(t, err.Error(), "invalid API token")
@@ -244,4 +244,43 @@ func TestNormalizeGitHubIssueError(t *testing.T) {
 
 	other := errors.New("some other error")
 	assert.Same(t, other, normalizeGitHubIssueError(other))
+}
+
+func TestGitHubIssueRepository_ListIssues_WithLabels(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v3/repos/testuser/testrepo/issues" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+
+		assert.Equal(t, "bug,release", r.URL.Query().Get("labels"))
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`[
+			{
+				"id": 1,
+				"number": 1,
+				"title": "Labeled Issue",
+				"body": "Test body",
+				"state": "closed",
+				"user": {"login": "testuser"},
+				"created_at": "2021-01-01T00:00:00Z"
+			}
+		]`))
+	}))
+	defer server.Close()
+
+	client := github.NewClient(nil)
+	client, err := client.WithEnterpriseURLs(server.URL, server.URL)
+	assert.NoError(t, err)
+	repo := &GitHubIssueRepository{client: client, logger: slog.Default()}
+
+	issues, err := repo.ListIssues(context.Background(), IssueListQuery{
+		Username:   "testuser",
+		Repository: "testrepo",
+		Labels:     []string{"bug", "release"},
+	})
+	assert.NoError(t, err)
+	assert.Len(t, issues, 1)
+	assert.Equal(t, "Labeled Issue", issues[0].GetTitle())
 }

--- a/pkg/core/issue_articles.go
+++ b/pkg/core/issue_articles.go
@@ -79,8 +79,19 @@ func (s *ArticleService) ConvertIssueToArticle(issue *github.Issue) *Article {
 	images = append(images, s.findImages(content, regexHTMLImage, time, len(images))...)
 
 	var tags []string
+	excludedLabels := map[string]struct{}{}
+	if s.config.GitHub != nil {
+		excludedLabels = make(map[string]struct{}, len(s.config.GitHub.Labels))
+		for _, label := range s.config.GitHub.Labels {
+			excludedLabels[label] = struct{}{}
+		}
+	}
 	for _, label := range issue.Labels {
-		tags = append(tags, label.GetName())
+		name := label.GetName()
+		if _, ok := excludedLabels[name]; ok {
+			continue
+		}
+		tags = append(tags, name)
 	}
 
 	return &Article{

--- a/pkg/core/issue_articles_test.go
+++ b/pkg/core/issue_articles_test.go
@@ -22,6 +22,7 @@ func TestArticleService_ConvertIssueToArticle(t *testing.T) {
 	conf := *config.NewConfig()
 	conf.Output.Images.BaseURL = Ptr("/images/%Y-%m-%d")
 	conf.Output.Images.Filename = "[:id].png"
+	conf.GitHub.Labels = []string{"published"}
 
 	service := NewArticleService(conf)
 
@@ -80,6 +81,23 @@ func TestArticleService_ConvertIssueToArticle(t *testing.T) {
 			},
 			want: map[string]interface{}{
 				"tags": []string{"bug", "enhancement"},
+			},
+		},
+		{
+			name: "フィルタ用ラベルはタグから除外",
+			issue: &github.Issue{
+				Title:     Ptr("Filtered Label Issue"),
+				Body:      Ptr("Content"),
+				CreatedAt: parseTime("2021-03-10T00:00:00Z"),
+				User:      &github.User{Login: Ptr("user")},
+				State:     Ptr("closed"),
+				Labels: []*github.Label{
+					{Name: Ptr("published")},
+					{Name: Ptr("go")},
+				},
+			},
+			want: map[string]interface{}{
+				"tags": []string{"go"},
 			},
 		},
 		{


### PR DESCRIPTION
## Summary

Add support for filtering fetched GitHub issues by label via `github.labels` in `gic.config.yaml`.

## Changes

- add `github.labels` to the config schema
- pass label filters to the GitHub issues API
- refactor issue listing to use an `IssueListQuery` struct instead of growing positional arguments
- exclude labels used for fetching from generated article `tags`
- update tests and configuration docs

## Example

```yaml
github:
  username: "rokuosan"
  repository: "github-issue-cms"
  labels:
    - "reviewed"
```

With this setting, only issues labeled `reviewed` are fetched, and `reviewed` itself is not included in the generated article tags.

## Testing

- `go test ./pkg/config ./cmd/cli ./cmd/cli/subcommand`
- `go test ./pkg/core`
