### PR TITLE
fix: avoid rendering empty custom front matter

### DIFF
--- a/pkg/core/article_renderer.go
+++ b/pkg/core/article_renderer.go
@@ -25,9 +25,13 @@ func (HugoArticleRenderer) Render(article *Article) (string, error) {
 	rendered := article.Clone()
 	applyFrontMatterOverrides(rendered, extra)
 
-	extraFrontMatter, err := NewFrontMatter(extra).MarshalYAML()
-	if err != nil {
-		return "", err
+	extraFrontMatter := []byte(nil)
+	if len(extra) > 0 {
+		var err error
+		extraFrontMatter, err = NewFrontMatter(extra).MarshalYAML()
+		if err != nil {
+			return "", err
+		}
 	}
 
 	partial, err := yaml.Marshal(rendered)

--- a/pkg/core/article_renderer_test.go
+++ b/pkg/core/article_renderer_test.go
@@ -36,7 +36,6 @@ tags:
     - tag1
     - tag2
 draft: false
-{}
 ---
 
 Test content
@@ -88,7 +87,6 @@ categories: Original
 tags:
     - original
 draft: true
-{}
 ---
 
 Test content


### PR DESCRIPTION
## Summary

This PR fixes a rendering bug where an empty custom front matter object (`{}`) was emitted into the generated front matter block.

## Root Cause

When custom front matter only contained fields already handled by the renderer, such as `title`, those known fields were consumed and removed before serialization. The remaining map became empty, but it was still marshaled and appended to the output, which produced `{}` in the front matter.

## Changes

- Skip serializing additional front matter when no custom keys remain after applying known field overrides.
- Update renderer tests to assert that empty custom front matter is no longer emitted.

## Impact

- Generated article front matter no longer includes a stray empty object.
- Cases with real custom front matter continue to render as before.

## Validation

- `go test ./pkg/core/...`
