### PR TITLE
fix: use front matter date for output path templates

### DIFF
--- a/pkg/core/content.go
+++ b/pkg/core/content.go
@@ -61,7 +61,7 @@ func NewImage(url, time string, id int) *Image {
 }
 
 func (a *Article) ParseDateTime() (time.Time, error) {
-	if t, err := time.Parse("2006-01-02T15:04:05Z", a.Date); err == nil {
+	if t, err := time.Parse(time.RFC3339, a.Date); err == nil {
 		return t, nil
 	}
 	if t, err := time.Parse("2006-01-02", a.Date); err == nil {

--- a/pkg/core/content_test.go
+++ b/pkg/core/content_test.go
@@ -59,6 +59,12 @@ func TestArticle_ParseDateTime(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name:    "RFC3339 offset format",
+			date:    "2021-02-03T04:05:06+09:00",
+			want:    time.Date(2021, 2, 3, 4, 5, 6, 0, time.FixedZone("+0900", 9*60*60)),
+			wantErr: false,
+		},
+		{
 			name:    "date only format",
 			date:    "2021-01-01",
 			want:    time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC),

--- a/pkg/core/filesystem_articles.go
+++ b/pkg/core/filesystem_articles.go
@@ -2,8 +2,6 @@ package core
 
 import (
 	"context"
-	"crypto/sha1"
-	"encoding/hex"
 	"fmt"
 	"io"
 	"log/slog"
@@ -11,6 +9,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
@@ -48,7 +47,10 @@ func (r *FileSystemArticleRepository) Save(ctx context.Context, article *Article
 		return err
 	}
 
-	datetime, err := article.ParseDateTime()
+	rendered := article.Clone()
+	applyFrontMatterOverrides(rendered, rendered.FrontMatter.Values())
+
+	datetime, err := rendered.ParseDateTime()
 	if err != nil {
 		return fmt.Errorf("failed to parse datetime: %w", err)
 	}
@@ -60,8 +62,6 @@ func (r *FileSystemArticleRepository) Save(ctx context.Context, article *Article
 	if err := createDirectoryIfNotExist(articleDir); err != nil {
 		return fmt.Errorf("failed to create directory %s: %w", articleDir, err)
 	}
-
-	rendered := article.Clone()
 
 	articlePath, err := resolveArticlePath(conf, datetime, articleDir)
 	if err != nil {
@@ -76,7 +76,7 @@ func (r *FileSystemArticleRepository) Save(ctx context.Context, article *Article
 		if err := ctx.Err(); err != nil {
 			return err
 		}
-		filename, err := r.saveImage(ctx, image, imageDir)
+		filename, err := r.saveImage(ctx, image, imageDir, conf, datetime)
 		if err != nil {
 			r.logger.Error("Failed to download image", "url", image.URL, "error", err)
 			continue
@@ -131,7 +131,7 @@ func createFileAndWrite(path string, content string) error {
 	return os.WriteFile(path, []byte(content), 0o644)
 }
 
-func (r *FileSystemArticleRepository) saveImage(ctx context.Context, image *Image, imageDir string) (string, error) {
+func (r *FileSystemArticleRepository) saveImage(ctx context.Context, image *Image, imageDir string, conf config.Config, datetime time.Time) (string, error) {
 	if err := createDirectoryIfNotExist(imageDir); err != nil {
 		return "", fmt.Errorf("failed to create directory %s: %w", imageDir, err)
 	}
@@ -142,7 +142,10 @@ func (r *FileSystemArticleRepository) saveImage(ctx context.Context, image *Imag
 	}
 	defer asset.Body.Close()
 
-	filename := resolveImageBasename(image) + extensionFromContentType(asset.ContentType)
+	filename := resolveImageFilename(conf, image, datetime)
+	if filepath.Ext(filename) == "" {
+		filename += extensionFromContentType(asset.ContentType)
+	}
 	if filepath.Ext(filename) == "" {
 		filename += ".img"
 	}
@@ -161,9 +164,14 @@ func (r *FileSystemArticleRepository) saveImage(ctx context.Context, image *Imag
 	return filename, nil
 }
 
-func resolveImageBasename(image *Image) string {
-	sum := sha1.Sum([]byte(image.URL))
-	return hex.EncodeToString(sum[:])[:12]
+func resolveImageFilename(conf config.Config, image *Image, datetime time.Time) string {
+	filename := conf.Output.Images.Filename
+	if filename == "" {
+		filename = "[:id]"
+	}
+
+	filename = config.CompileTimeTemplate(datetime, filename)
+	return strings.ReplaceAll(filename, "[:id]", strconv.Itoa(image.ID))
 }
 
 func joinURLPath(base, filename string) string {

--- a/pkg/core/filesystem_articles_test.go
+++ b/pkg/core/filesystem_articles_test.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/rokuosan/github-issue-cms/pkg/config"
 	"github.com/stretchr/testify/assert"
@@ -34,6 +35,7 @@ func TestFileSystemArticleRepository_Save_RewritesImageURLs(t *testing.T) {
 	conf.Output.Images.Directory = filepath.Join(tempDir, "static", "images", "%Y-%m-%d")
 	conf.Output.Images.BaseURL = Ptr("/images/%Y-%m-%d")
 	conf.Output.Articles.Filename = "index.md"
+	conf.Output.Images.Filename = "[:id].png"
 
 	imageURL := "https://example.com/image.jpeg"
 	imageRepo := &fakeImageRepository{contentType: "image/jpeg", body: "jpeg"}
@@ -61,11 +63,63 @@ func TestFileSystemArticleRepository_Save_RewritesImageURLs(t *testing.T) {
 	outputPath := filepath.Join(tempDir, "content", "2021-01-01", "index.md")
 	data, err := os.ReadFile(outputPath)
 	require.NoError(t, err)
-	expectedFilename := resolveImageBasename(NewImage(imageURL, "2021-01-01_000000", 0)) + ".jpg"
+	expectedFilename := "0.png"
 	assert.Contains(t, string(data), "![image](/images/2021-01-01/"+expectedFilename+")")
 
 	imagePath := filepath.Join(tempDir, "static", "images", "2021-01-01", expectedFilename)
 	imageData, err := os.ReadFile(imagePath)
 	require.NoError(t, err)
 	assertEqualCmp(t, "jpeg", string(imageData))
+}
+
+func TestFileSystemArticleRepository_Save_UsesFrontMatterDateForOutputPaths(t *testing.T) {
+	tempDir := t.TempDir()
+
+	conf := *config.NewConfig()
+	conf.Output.Articles.Directory = filepath.Join(tempDir, "content", "%Y-%m-%d_%H%M%S")
+	conf.Output.Articles.Filename = "index.md"
+	conf.Output.Images.Directory = filepath.Join(tempDir, "content", "%Y-%m-%d_%H%M%S", "images")
+	conf.Output.Images.BaseURL = Ptr("/images/%Y-%m-%d_%H%M%S")
+	conf.Output.Images.Filename = "%H-[:id].png"
+
+	imageURL := "https://example.com/image.png"
+	repo := &FileSystemArticleRepository{
+		imageRepo: &fakeImageRepository{contentType: "image/png", body: "png"},
+		renderer:  NewHugoArticleRenderer(),
+		logger:    slog.Default(),
+	}
+
+	article := &Article{
+		Author:      "Author",
+		Title:       "Title",
+		Content:     "![image](" + imageURL + ")",
+		Date:        "2021-01-01T00:00:00Z",
+		FrontMatter: NewFrontMatter(map[string]any{"date": "2021-02-03T04:05:06Z"}),
+		Images: []*Image{
+			NewImage(imageURL, "2021-01-01_000000", 0),
+		},
+	}
+
+	err := repo.Save(context.Background(), article, conf)
+	require.NoError(t, err)
+
+	outputPath := filepath.Join(tempDir, "content", "2021-02-03_040506", "index.md")
+	data, err := os.ReadFile(outputPath)
+	require.NoError(t, err)
+	assert.Contains(t, string(data), `date: "2021-02-03T04:05:06Z"`)
+	assert.Contains(t, string(data), "![image](/images/2021-02-03_040506/04-0.png)")
+
+	imagePath := filepath.Join(tempDir, "content", "2021-02-03_040506", "images", "04-0.png")
+	imageData, err := os.ReadFile(imagePath)
+	require.NoError(t, err)
+	assertEqualCmp(t, "png", string(imageData))
+}
+
+func TestResolveImageFilename_UsesResolvedArticleDatetime(t *testing.T) {
+	conf := *config.NewConfig()
+	conf.Output.Images.Filename = "%H-[:id].png"
+
+	datetime := time.Date(2021, 2, 3, 4, 5, 6, 0, time.UTC)
+	got := resolveImageFilename(conf, NewImage("https://example.com/image.png", "2021-01-01_000000", 7), datetime)
+	assertEqualCmp(t, "04-7.png", got)
 }

--- a/pkg/core/filesystem_articles_test.go
+++ b/pkg/core/filesystem_articles_test.go
@@ -115,6 +115,44 @@ func TestFileSystemArticleRepository_Save_UsesFrontMatterDateForOutputPaths(t *t
 	assertEqualCmp(t, "png", string(imageData))
 }
 
+func TestFileSystemArticleRepository_Save_AcceptsFrontMatterDateWithOffset(t *testing.T) {
+	tempDir := t.TempDir()
+
+	conf := *config.NewConfig()
+	conf.Output.Articles.Directory = filepath.Join(tempDir, "content", "%Y-%m-%d_%H%M%S")
+	conf.Output.Articles.Filename = "index.md"
+	conf.Output.Images.Directory = filepath.Join(tempDir, "content", "%Y-%m-%d_%H%M%S", "images")
+	conf.Output.Images.BaseURL = Ptr("/images/%Y-%m-%d_%H%M%S")
+	conf.Output.Images.Filename = "%H-[:id].png"
+
+	imageURL := "https://example.com/image.png"
+	repo := &FileSystemArticleRepository{
+		imageRepo: &fakeImageRepository{contentType: "image/png", body: "png"},
+		renderer:  NewHugoArticleRenderer(),
+		logger:    slog.Default(),
+	}
+
+	article := &Article{
+		Author:      "Author",
+		Title:       "Title",
+		Content:     "![image](" + imageURL + ")",
+		Date:        "2021-01-01T00:00:00Z",
+		FrontMatter: NewFrontMatter(map[string]any{"date": "2021-02-03T04:05:06+09:00"}),
+		Images: []*Image{
+			NewImage(imageURL, "2021-01-01_000000", 0),
+		},
+	}
+
+	err := repo.Save(context.Background(), article, conf)
+	require.NoError(t, err)
+
+	outputPath := filepath.Join(tempDir, "content", "2021-02-03_040506", "index.md")
+	data, err := os.ReadFile(outputPath)
+	require.NoError(t, err)
+	assert.Contains(t, string(data), `date: "2021-02-03T04:05:06+09:00"`)
+	assert.Contains(t, string(data), "![image](/images/2021-02-03_040506/04-0.png)")
+}
+
 func TestResolveImageFilename_UsesResolvedArticleDatetime(t *testing.T) {
 	conf := *config.NewConfig()
 	conf.Output.Images.Filename = "%H-[:id].png"


### PR DESCRIPTION
## Summary
- use front matter overrides before resolving article output datetime
- apply the resolved datetime to article paths, image directories, image filenames, and image URLs
- add regression coverage for page bundle paths and image filename templates

## Root cause
The exporter resolved `%Y/%m/%d/%H/%M/%S` placeholders from the issue-created date before applying front matter overrides, so `date` in front matter did not affect output paths.

## Validation
- go test ./pkg/core ./pkg/config ./cmd/cli/...