### PR TITLE
refactor: collect and replace GitHub-hosted attachment URLs only

### DIFF
--- a/pkg/core/filesystem_articles.go
+++ b/pkg/core/filesystem_articles.go
@@ -72,6 +72,7 @@ func (r *FileSystemArticleRepository) Save(ctx context.Context, article *Article
 	if err != nil {
 		return err
 	}
+	replacements := make([]string, 0, len(rendered.Images)*2)
 	for _, image := range rendered.Images {
 		if err := ctx.Err(); err != nil {
 			return err
@@ -81,7 +82,10 @@ func (r *FileSystemArticleRepository) Save(ctx context.Context, article *Article
 			r.logger.Error("Failed to download image", "url", image.URL, "error", err)
 			continue
 		}
-		rendered.Content = strings.ReplaceAll(rendered.Content, image.URL, joinURLPath(imageURLBase, filename))
+		replacements = append(replacements, image.URL, joinURLPath(imageURLBase, filename))
+	}
+	if len(replacements) > 0 {
+		rendered.Content = strings.NewReplacer(replacements...).Replace(rendered.Content)
 	}
 
 	text, err := r.renderer.Render(rendered)

--- a/pkg/core/filesystem_articles_test.go
+++ b/pkg/core/filesystem_articles_test.go
@@ -29,15 +29,15 @@ func (r *fakeImageRepository) Fetch(ctx context.Context, image *Image) (*ImageAs
 
 func TestFileSystemArticleRepository_Save_RewritesImageURLs(t *testing.T) {
 	tests := []struct {
-		name                string
-		contentType         string
-		body                string
-		content             string
-		images              []*Image
-		wantContains        []string
-		wantNotContains     []string
-		wantSavedFilename   string
-		wantSavedFileBody   string
+		name              string
+		contentType       string
+		body              string
+		content           string
+		images            []*Image
+		wantContains      []string
+		wantNotContains   []string
+		wantSavedFilename string
+		wantSavedFileBody string
 	}{
 		{
 			name:              "rewrites markdown image URLs",

--- a/pkg/core/filesystem_articles_test.go
+++ b/pkg/core/filesystem_articles_test.go
@@ -72,6 +72,84 @@ func TestFileSystemArticleRepository_Save_RewritesImageURLs(t *testing.T) {
 	assertEqualCmp(t, "jpeg", string(imageData))
 }
 
+func TestFileSystemArticleRepository_Save_RewritesHTMLImageURLs(t *testing.T) {
+	tempDir := t.TempDir()
+
+	conf := *config.NewConfig()
+	conf.Output.Articles.Directory = filepath.Join(tempDir, "content", "%Y-%m-%d")
+	conf.Output.Images.Directory = filepath.Join(tempDir, "static", "images", "%Y-%m-%d")
+	conf.Output.Images.BaseURL = Ptr("/images/%Y-%m-%d")
+	conf.Output.Articles.Filename = "index.md"
+	conf.Output.Images.Filename = "[:id].png"
+
+	imageURL := "https://example.com/test.png"
+	repo := &FileSystemArticleRepository{
+		imageRepo: &fakeImageRepository{contentType: "image/png", body: "png"},
+		renderer:  NewHugoArticleRenderer(),
+		logger:    slog.Default(),
+	}
+
+	article := &Article{
+		Author:  "Author",
+		Title:   "Title",
+		Content: `<img class="rounded" src="` + imageURL + `" alt="test image" loading="lazy">`,
+		Date:    "2021-01-01T00:00:00Z",
+		Images: []*Image{
+			NewImage(imageURL, "2021-01-01_000000", 0),
+		},
+	}
+
+	err := repo.Save(context.Background(), article, conf)
+	require.NoError(t, err)
+
+	outputPath := filepath.Join(tempDir, "content", "2021-01-01", "index.md")
+	data, err := os.ReadFile(outputPath)
+	require.NoError(t, err)
+	assert.Contains(t, string(data), `<img class="rounded" src="/images/2021-01-01/0.png" alt="test image" loading="lazy">`)
+}
+
+func TestFileSystemArticleRepository_Save_RewritesGitHubHostedImageURLsInOnePass(t *testing.T) {
+	tempDir := t.TempDir()
+
+	conf := *config.NewConfig()
+	conf.Output.Articles.Directory = filepath.Join(tempDir, "content", "%Y-%m-%d")
+	conf.Output.Images.Directory = filepath.Join(tempDir, "static", "images", "%Y-%m-%d")
+	conf.Output.Images.BaseURL = Ptr("/images/%Y-%m-%d")
+	conf.Output.Articles.Filename = "index.md"
+	conf.Output.Images.Filename = "[:id].png"
+
+	firstURL := "https://github.com/user-attachments/assets/11111111-1111-1111-1111-111111111111"
+	secondURL := "https://github.com/user-attachments/assets/22222222-2222-2222-2222-222222222222"
+	repo := &FileSystemArticleRepository{
+		imageRepo: &fakeImageRepository{contentType: "image/png", body: "png"},
+		renderer:  NewHugoArticleRenderer(),
+		logger:    slog.Default(),
+	}
+
+	article := &Article{
+		Author: "Author",
+		Title:  "Title",
+		Content: "![first](" + firstURL + ")\n\n" +
+			`<img src="` + secondURL + `" alt="second">`,
+		Date: "2021-01-01T00:00:00Z",
+		Images: []*Image{
+			NewImage(firstURL, "2021-01-01_000000", 0),
+			NewImage(secondURL, "2021-01-01_000000", 1),
+		},
+	}
+
+	err := repo.Save(context.Background(), article, conf)
+	require.NoError(t, err)
+
+	outputPath := filepath.Join(tempDir, "content", "2021-01-01", "index.md")
+	data, err := os.ReadFile(outputPath)
+	require.NoError(t, err)
+	assert.Contains(t, string(data), "![first](/images/2021-01-01/0.png)")
+	assert.Contains(t, string(data), `<img src="/images/2021-01-01/1.png" alt="second">`)
+	assert.NotContains(t, string(data), firstURL)
+	assert.NotContains(t, string(data), secondURL)
+}
+
 func TestFileSystemArticleRepository_Save_UsesFrontMatterDateForOutputPaths(t *testing.T) {
 	tempDir := t.TempDir()
 

--- a/pkg/core/filesystem_articles_test.go
+++ b/pkg/core/filesystem_articles_test.go
@@ -28,126 +28,108 @@ func (r *fakeImageRepository) Fetch(ctx context.Context, image *Image) (*ImageAs
 }
 
 func TestFileSystemArticleRepository_Save_RewritesImageURLs(t *testing.T) {
-	tempDir := t.TempDir()
-
-	conf := *config.NewConfig()
-	conf.Output.Articles.Directory = filepath.Join(tempDir, "content", "%Y-%m-%d")
-	conf.Output.Images.Directory = filepath.Join(tempDir, "static", "images", "%Y-%m-%d")
-	conf.Output.Images.BaseURL = Ptr("/images/%Y-%m-%d")
-	conf.Output.Articles.Filename = "index.md"
-	conf.Output.Images.Filename = "[:id].png"
-
-	imageURL := "https://example.com/image.jpeg"
-	imageRepo := &fakeImageRepository{contentType: "image/jpeg", body: "jpeg"}
-	repo := &FileSystemArticleRepository{
-		imageRepo: imageRepo,
-		renderer:  NewHugoArticleRenderer(),
-		logger:    slog.Default(),
-	}
-
-	article := &Article{
-		Author:   "Author",
-		Title:    "Title",
-		Content:  "![image](" + imageURL + ")",
-		Date:     "2021-01-01T00:00:00Z",
-		Category: "Category",
-		Tags:     []string{"tag"},
-		Images: []*Image{
-			NewImage(imageURL, "2021-01-01_000000", 0),
+	tests := []struct {
+		name                string
+		contentType         string
+		body                string
+		content             string
+		images              []*Image
+		wantContains        []string
+		wantNotContains     []string
+		wantSavedFilename   string
+		wantSavedFileBody   string
+	}{
+		{
+			name:              "rewrites markdown image URLs",
+			contentType:       "image/jpeg",
+			body:              "jpeg",
+			content:           "![image](https://example.com/image.jpeg)",
+			images:            []*Image{NewImage("https://example.com/image.jpeg", "2021-01-01_000000", 0)},
+			wantContains:      []string{"![image](/images/2021-01-01/0.png)"},
+			wantSavedFilename: "0.png",
+			wantSavedFileBody: "jpeg",
+		},
+		{
+			name:        "rewrites HTML image URLs",
+			contentType: "image/png",
+			body:        "png",
+			content:     `<img class="rounded" src="https://example.com/test.png" alt="test image" loading="lazy">`,
+			images:      []*Image{NewImage("https://example.com/test.png", "2021-01-01_000000", 0)},
+			wantContains: []string{
+				`<img class="rounded" src="/images/2021-01-01/0.png" alt="test image" loading="lazy">`,
+			},
+			wantSavedFilename: "0.png",
+			wantSavedFileBody: "png",
+		},
+		{
+			name:        "rewrites multiple GitHub-hosted image URLs in one pass",
+			contentType: "image/png",
+			body:        "png",
+			content: "![first](https://github.com/user-attachments/assets/11111111-1111-1111-1111-111111111111)\n\n" +
+				`<img src="https://github.com/user-attachments/assets/22222222-2222-2222-2222-222222222222" alt="second">`,
+			images: []*Image{
+				NewImage("https://github.com/user-attachments/assets/11111111-1111-1111-1111-111111111111", "2021-01-01_000000", 0),
+				NewImage("https://github.com/user-attachments/assets/22222222-2222-2222-2222-222222222222", "2021-01-01_000000", 1),
+			},
+			wantContains: []string{
+				"![first](/images/2021-01-01/0.png)",
+				`<img src="/images/2021-01-01/1.png" alt="second">`,
+			},
+			wantNotContains: []string{
+				"https://github.com/user-attachments/assets/11111111-1111-1111-1111-111111111111",
+				"https://github.com/user-attachments/assets/22222222-2222-2222-2222-222222222222",
+			},
+			wantSavedFilename: "0.png",
+			wantSavedFileBody: "png",
 		},
 	}
 
-	err := repo.Save(context.Background(), article, conf)
-	require.NoError(t, err)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tempDir := t.TempDir()
 
-	outputPath := filepath.Join(tempDir, "content", "2021-01-01", "index.md")
-	data, err := os.ReadFile(outputPath)
-	require.NoError(t, err)
-	expectedFilename := "0.png"
-	assert.Contains(t, string(data), "![image](/images/2021-01-01/"+expectedFilename+")")
+			conf := *config.NewConfig()
+			conf.Output.Articles.Directory = filepath.Join(tempDir, "content", "%Y-%m-%d")
+			conf.Output.Images.Directory = filepath.Join(tempDir, "static", "images", "%Y-%m-%d")
+			conf.Output.Images.BaseURL = Ptr("/images/%Y-%m-%d")
+			conf.Output.Articles.Filename = "index.md"
+			conf.Output.Images.Filename = "[:id].png"
 
-	imagePath := filepath.Join(tempDir, "static", "images", "2021-01-01", expectedFilename)
-	imageData, err := os.ReadFile(imagePath)
-	require.NoError(t, err)
-	assertEqualCmp(t, "jpeg", string(imageData))
-}
+			repo := &FileSystemArticleRepository{
+				imageRepo: &fakeImageRepository{contentType: tt.contentType, body: tt.body},
+				renderer:  NewHugoArticleRenderer(),
+				logger:    slog.Default(),
+			}
 
-func TestFileSystemArticleRepository_Save_RewritesHTMLImageURLs(t *testing.T) {
-	tempDir := t.TempDir()
+			article := &Article{
+				Author:   "Author",
+				Title:    "Title",
+				Content:  tt.content,
+				Date:     "2021-01-01T00:00:00Z",
+				Category: "Category",
+				Tags:     []string{"tag"},
+				Images:   tt.images,
+			}
 
-	conf := *config.NewConfig()
-	conf.Output.Articles.Directory = filepath.Join(tempDir, "content", "%Y-%m-%d")
-	conf.Output.Images.Directory = filepath.Join(tempDir, "static", "images", "%Y-%m-%d")
-	conf.Output.Images.BaseURL = Ptr("/images/%Y-%m-%d")
-	conf.Output.Articles.Filename = "index.md"
-	conf.Output.Images.Filename = "[:id].png"
+			err := repo.Save(context.Background(), article, conf)
+			require.NoError(t, err)
 
-	imageURL := "https://example.com/test.png"
-	repo := &FileSystemArticleRepository{
-		imageRepo: &fakeImageRepository{contentType: "image/png", body: "png"},
-		renderer:  NewHugoArticleRenderer(),
-		logger:    slog.Default(),
+			outputPath := filepath.Join(tempDir, "content", "2021-01-01", "index.md")
+			data, err := os.ReadFile(outputPath)
+			require.NoError(t, err)
+			for _, want := range tt.wantContains {
+				assert.Contains(t, string(data), want)
+			}
+			for _, unwanted := range tt.wantNotContains {
+				assert.NotContains(t, string(data), unwanted)
+			}
+
+			imagePath := filepath.Join(tempDir, "static", "images", "2021-01-01", tt.wantSavedFilename)
+			imageData, err := os.ReadFile(imagePath)
+			require.NoError(t, err)
+			assertEqualCmp(t, tt.wantSavedFileBody, string(imageData))
+		})
 	}
-
-	article := &Article{
-		Author:  "Author",
-		Title:   "Title",
-		Content: `<img class="rounded" src="` + imageURL + `" alt="test image" loading="lazy">`,
-		Date:    "2021-01-01T00:00:00Z",
-		Images: []*Image{
-			NewImage(imageURL, "2021-01-01_000000", 0),
-		},
-	}
-
-	err := repo.Save(context.Background(), article, conf)
-	require.NoError(t, err)
-
-	outputPath := filepath.Join(tempDir, "content", "2021-01-01", "index.md")
-	data, err := os.ReadFile(outputPath)
-	require.NoError(t, err)
-	assert.Contains(t, string(data), `<img class="rounded" src="/images/2021-01-01/0.png" alt="test image" loading="lazy">`)
-}
-
-func TestFileSystemArticleRepository_Save_RewritesGitHubHostedImageURLsInOnePass(t *testing.T) {
-	tempDir := t.TempDir()
-
-	conf := *config.NewConfig()
-	conf.Output.Articles.Directory = filepath.Join(tempDir, "content", "%Y-%m-%d")
-	conf.Output.Images.Directory = filepath.Join(tempDir, "static", "images", "%Y-%m-%d")
-	conf.Output.Images.BaseURL = Ptr("/images/%Y-%m-%d")
-	conf.Output.Articles.Filename = "index.md"
-	conf.Output.Images.Filename = "[:id].png"
-
-	firstURL := "https://github.com/user-attachments/assets/11111111-1111-1111-1111-111111111111"
-	secondURL := "https://github.com/user-attachments/assets/22222222-2222-2222-2222-222222222222"
-	repo := &FileSystemArticleRepository{
-		imageRepo: &fakeImageRepository{contentType: "image/png", body: "png"},
-		renderer:  NewHugoArticleRenderer(),
-		logger:    slog.Default(),
-	}
-
-	article := &Article{
-		Author: "Author",
-		Title:  "Title",
-		Content: "![first](" + firstURL + ")\n\n" +
-			`<img src="` + secondURL + `" alt="second">`,
-		Date: "2021-01-01T00:00:00Z",
-		Images: []*Image{
-			NewImage(firstURL, "2021-01-01_000000", 0),
-			NewImage(secondURL, "2021-01-01_000000", 1),
-		},
-	}
-
-	err := repo.Save(context.Background(), article, conf)
-	require.NoError(t, err)
-
-	outputPath := filepath.Join(tempDir, "content", "2021-01-01", "index.md")
-	data, err := os.ReadFile(outputPath)
-	require.NoError(t, err)
-	assert.Contains(t, string(data), "![first](/images/2021-01-01/0.png)")
-	assert.Contains(t, string(data), `<img src="/images/2021-01-01/1.png" alt="second">`)
-	assert.NotContains(t, string(data), firstURL)
-	assert.NotContains(t, string(data), secondURL)
 }
 
 func TestFileSystemArticleRepository_Save_UsesFrontMatterDateForOutputPaths(t *testing.T) {

--- a/pkg/core/issue_articles.go
+++ b/pkg/core/issue_articles.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"fmt"
+	"net/url"
 	"regexp"
 	"strings"
 
@@ -12,8 +13,11 @@ import (
 )
 
 var (
-	regexMarkdownImage = regexp.MustCompile(`!\[[^\]]*]\((.+?)\)`)
-	regexHTMLImage     = regexp.MustCompile(`<img width="\d+" alt="(\w+)" src="(\S+)">`)
+	regexURLCandidate = regexp.MustCompile(`https://[^\s<>"')\]]+`)
+	gitHubAssetHosts  = map[string]struct{}{
+		"github.com":                              {},
+		"private-user-images.githubusercontent.com": {},
+	}
 )
 
 // ArticleService converts issues into articles.
@@ -73,10 +77,7 @@ func (s *ArticleService) ConvertIssueToArticle(issue *github.Issue) *Article {
 	content = strings.TrimLeft(content, "\n")
 
 	time := issue.GetCreatedAt().Format("2006-01-02_150405")
-
-	var images []*Image
-	images = append(images, s.findImages(content, regexMarkdownImage, time, 0)...)
-	images = append(images, s.findImages(content, regexHTMLImage, time, len(images))...)
+	images := extractGitHubHostedImages(content, time)
 
 	var tags []string
 	excludedLabels := map[string]struct{}{}
@@ -108,20 +109,39 @@ func (s *ArticleService) ConvertIssueToArticle(issue *github.Issue) *Article {
 	}
 }
 
-func (s *ArticleService) findImages(content string, re *regexp.Regexp, time string, offset int) []*Image {
+func extractGitHubHostedImages(content string, time string) []*Image {
 	var images []*Image
-
-	matches := re.FindAllStringSubmatch(content, -1)
-	for i, m := range matches {
-		id := i + offset
-		url := m[1]
-		if len(m) > 2 {
-			url = m[2]
+	seen := map[string]struct{}{}
+	matches := regexURLCandidate.FindAllString(content, -1)
+	for _, match := range matches {
+		candidate := strings.TrimRight(match, ".,:;!?")
+		if !isGitHubHostedAssetURL(candidate) {
+			continue
 		}
-		images = append(images, NewImage(url, time, id))
+		if _, ok := seen[candidate]; ok {
+			continue
+		}
+		seen[candidate] = struct{}{}
+		images = append(images, NewImage(candidate, time, len(images)))
 	}
-
 	return images
+}
+
+func isGitHubHostedAssetURL(raw string) bool {
+	parsed, err := url.Parse(raw)
+	if err != nil {
+		return false
+	}
+	host := strings.ToLower(parsed.Host)
+	if _, ok := gitHubAssetHosts[host]; !ok {
+		return false
+	}
+	switch host {
+	case "github.com":
+		return strings.HasPrefix(parsed.Path, "/user-attachments/")
+	default:
+		return true
+	}
 }
 
 func newMetadataParser() metadataParser {

--- a/pkg/core/issue_articles.go
+++ b/pkg/core/issue_articles.go
@@ -15,8 +15,8 @@ import (
 var (
 	regexURLCandidate = regexp.MustCompile(`https://[^\s<>"')\]]+`)
 	gitHubAssetHosts  = map[string]struct{}{
-		"github.com":                              {},
-		"user-images.githubusercontent.com":       {},
+		"github.com":                                {},
+		"user-images.githubusercontent.com":         {},
 		"private-user-images.githubusercontent.com": {},
 	}
 )

--- a/pkg/core/issue_articles.go
+++ b/pkg/core/issue_articles.go
@@ -115,7 +115,7 @@ func extractGitHubHostedImages(content string, time string) []*Image {
 	seen := map[string]struct{}{}
 	matches := regexURLCandidate.FindAllString(content, -1)
 	for _, match := range matches {
-		candidate := strings.TrimRight(match, ".,:;!?")
+		candidate := strings.TrimRight(match, ".,:;!?`")
 		if !isGitHubHostedAssetURL(candidate) {
 			continue
 		}

--- a/pkg/core/issue_articles.go
+++ b/pkg/core/issue_articles.go
@@ -16,6 +16,7 @@ var (
 	regexURLCandidate = regexp.MustCompile(`https://[^\s<>"')\]]+`)
 	gitHubAssetHosts  = map[string]struct{}{
 		"github.com":                              {},
+		"user-images.githubusercontent.com":       {},
 		"private-user-images.githubusercontent.com": {},
 	}
 )

--- a/pkg/core/issue_articles_test.go
+++ b/pkg/core/issue_articles_test.go
@@ -241,6 +241,19 @@ func TestExtractGitHubHostedImages_DeduplicatesURLs(t *testing.T) {
 	assertEqualCmp(t, 2, got[2].ID)
 }
 
+func TestExtractGitHubHostedImages_TrimsTrailingBackticks(t *testing.T) {
+	content := strings.Join([]string{
+		"`https://github.com/user-attachments/assets/11111111-1111-1111-1111-111111111111`",
+		"`https://private-user-images.githubusercontent.com/22222222/33333333-4444-5555-6666-777777777777.png?jwt=token`,",
+	}, "\n")
+
+	got := extractGitHubHostedImages(content, "2021-01-01_000000")
+
+	require.Len(t, got, 2)
+	assertEqualCmp(t, "https://github.com/user-attachments/assets/11111111-1111-1111-1111-111111111111", got[0].URL)
+	assertEqualCmp(t, "https://private-user-images.githubusercontent.com/22222222/33333333-4444-5555-6666-777777777777.png?jwt=token", got[1].URL)
+}
+
 func TestArticleService_ConvertIssueToArticle_PullRequest(t *testing.T) {
 	service := NewArticleService(*config.NewConfig())
 

--- a/pkg/core/issue_articles_test.go
+++ b/pkg/core/issue_articles_test.go
@@ -222,36 +222,50 @@ func TestArticleService_ConvertIssueToArticle(t *testing.T) {
 	}
 }
 
-func TestExtractGitHubHostedImages_DeduplicatesURLs(t *testing.T) {
-	content := strings.Join([]string{
-		"![a](https://github.com/user-attachments/assets/11111111-1111-1111-1111-111111111111)",
-		`<img src="https://github.com/user-attachments/assets/11111111-1111-1111-1111-111111111111">`,
-		"https://private-user-images.githubusercontent.com/22222222/33333333-4444-5555-6666-777777777777.png?jwt=token",
-		"https://user-images.githubusercontent.com/1234567/abcdef01-2345-6789-abcd-ef0123456789.png",
-	}, "\n")
+func TestExtractGitHubHostedImages(t *testing.T) {
+	tests := []struct {
+		name     string
+		content  string
+		wantURLs []string
+	}{
+		{
+			name: "deduplicates repeated URLs and keeps detection order",
+			content: strings.Join([]string{
+				"![a](https://github.com/user-attachments/assets/11111111-1111-1111-1111-111111111111)",
+				`<img src="https://github.com/user-attachments/assets/11111111-1111-1111-1111-111111111111">`,
+				"https://private-user-images.githubusercontent.com/22222222/33333333-4444-5555-6666-777777777777.png?jwt=token",
+				"https://user-images.githubusercontent.com/1234567/abcdef01-2345-6789-abcd-ef0123456789.png",
+			}, "\n"),
+			wantURLs: []string{
+				"https://github.com/user-attachments/assets/11111111-1111-1111-1111-111111111111",
+				"https://private-user-images.githubusercontent.com/22222222/33333333-4444-5555-6666-777777777777.png?jwt=token",
+				"https://user-images.githubusercontent.com/1234567/abcdef01-2345-6789-abcd-ef0123456789.png",
+			},
+		},
+		{
+			name: "trims trailing backticks and punctuation",
+			content: strings.Join([]string{
+				"`https://github.com/user-attachments/assets/11111111-1111-1111-1111-111111111111`",
+				"`https://private-user-images.githubusercontent.com/22222222/33333333-4444-5555-6666-777777777777.png?jwt=token`,",
+			}, "\n"),
+			wantURLs: []string{
+				"https://github.com/user-attachments/assets/11111111-1111-1111-1111-111111111111",
+				"https://private-user-images.githubusercontent.com/22222222/33333333-4444-5555-6666-777777777777.png?jwt=token",
+			},
+		},
+	}
 
-	got := extractGitHubHostedImages(content, "2021-01-01_000000")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := extractGitHubHostedImages(tt.content, "2021-01-01_000000")
 
-	require.Len(t, got, 3)
-	assertEqualCmp(t, "https://github.com/user-attachments/assets/11111111-1111-1111-1111-111111111111", got[0].URL)
-	assertEqualCmp(t, 0, got[0].ID)
-	assertEqualCmp(t, "https://private-user-images.githubusercontent.com/22222222/33333333-4444-5555-6666-777777777777.png?jwt=token", got[1].URL)
-	assertEqualCmp(t, 1, got[1].ID)
-	assertEqualCmp(t, "https://user-images.githubusercontent.com/1234567/abcdef01-2345-6789-abcd-ef0123456789.png", got[2].URL)
-	assertEqualCmp(t, 2, got[2].ID)
-}
-
-func TestExtractGitHubHostedImages_TrimsTrailingBackticks(t *testing.T) {
-	content := strings.Join([]string{
-		"`https://github.com/user-attachments/assets/11111111-1111-1111-1111-111111111111`",
-		"`https://private-user-images.githubusercontent.com/22222222/33333333-4444-5555-6666-777777777777.png?jwt=token`,",
-	}, "\n")
-
-	got := extractGitHubHostedImages(content, "2021-01-01_000000")
-
-	require.Len(t, got, 2)
-	assertEqualCmp(t, "https://github.com/user-attachments/assets/11111111-1111-1111-1111-111111111111", got[0].URL)
-	assertEqualCmp(t, "https://private-user-images.githubusercontent.com/22222222/33333333-4444-5555-6666-777777777777.png?jwt=token", got[1].URL)
+			require.Len(t, got, len(tt.wantURLs))
+			for i, wantURL := range tt.wantURLs {
+				assertEqualCmp(t, wantURL, got[i].URL)
+				assertEqualCmp(t, i, got[i].ID)
+			}
+		})
+	}
 }
 
 func TestArticleService_ConvertIssueToArticle_PullRequest(t *testing.T) {

--- a/pkg/core/issue_articles_test.go
+++ b/pkg/core/issue_articles_test.go
@@ -168,6 +168,7 @@ func TestArticleService_ConvertIssueToArticle(t *testing.T) {
 				Body: Ptr(
 					"![image](https://github.com/user-attachments/assets/11111111-1111-1111-1111-111111111111)\n\n" +
 						`<img src="https://private-user-images.githubusercontent.com/22222222/33333333-4444-5555-6666-777777777777.png?jwt=token" alt="test">` + "\n\n" +
+						"[legacy](https://user-images.githubusercontent.com/1234567/abcdef01-2345-6789-abcd-ef0123456789.png)\n\n" +
 						"![ignored](https://example.com/image.png)",
 				),
 				CreatedAt: parseTime("2021-04-01T15:00:00Z"),
@@ -176,7 +177,7 @@ func TestArticleService_ConvertIssueToArticle(t *testing.T) {
 				Labels:    []*github.Label{},
 			},
 			want: map[string]interface{}{
-				"imageCount": 2,
+				"imageCount": 3,
 			},
 		},
 	}
@@ -226,15 +227,18 @@ func TestExtractGitHubHostedImages_DeduplicatesURLs(t *testing.T) {
 		"![a](https://github.com/user-attachments/assets/11111111-1111-1111-1111-111111111111)",
 		`<img src="https://github.com/user-attachments/assets/11111111-1111-1111-1111-111111111111">`,
 		"https://private-user-images.githubusercontent.com/22222222/33333333-4444-5555-6666-777777777777.png?jwt=token",
+		"https://user-images.githubusercontent.com/1234567/abcdef01-2345-6789-abcd-ef0123456789.png",
 	}, "\n")
 
 	got := extractGitHubHostedImages(content, "2021-01-01_000000")
 
-	require.Len(t, got, 2)
+	require.Len(t, got, 3)
 	assertEqualCmp(t, "https://github.com/user-attachments/assets/11111111-1111-1111-1111-111111111111", got[0].URL)
 	assertEqualCmp(t, 0, got[0].ID)
 	assertEqualCmp(t, "https://private-user-images.githubusercontent.com/22222222/33333333-4444-5555-6666-777777777777.png?jwt=token", got[1].URL)
 	assertEqualCmp(t, 1, got[1].ID)
+	assertEqualCmp(t, "https://user-images.githubusercontent.com/1234567/abcdef01-2345-6789-abcd-ef0123456789.png", got[2].URL)
+	assertEqualCmp(t, 2, got[2].ID)
 }
 
 func TestArticleService_ConvertIssueToArticle_PullRequest(t *testing.T) {

--- a/pkg/core/issue_articles_test.go
+++ b/pkg/core/issue_articles_test.go
@@ -1,6 +1,7 @@
 package core
 
 import (
+	"strings"
 	"testing"
 	"time"
 
@@ -161,10 +162,14 @@ func TestArticleService_ConvertIssueToArticle(t *testing.T) {
 			},
 		},
 		{
-			name: "Markdown画像付きIssue",
+			name: "既知のGitHubコンテンツURLだけを収集",
 			issue: &github.Issue{
-				Title:     Ptr("Image Issue"),
-				Body:      Ptr("![image](https://example.com/image1.png)\n\n![image](https://example.com/image2.png)"),
+				Title: Ptr("GitHub Asset Issue"),
+				Body: Ptr(
+					"![image](https://github.com/user-attachments/assets/11111111-1111-1111-1111-111111111111)\n\n" +
+						`<img src="https://private-user-images.githubusercontent.com/22222222/33333333-4444-5555-6666-777777777777.png?jwt=token" alt="test">` + "\n\n" +
+						"![ignored](https://example.com/image.png)",
+				),
 				CreatedAt: parseTime("2021-04-01T15:00:00Z"),
 				User:      &github.User{Login: Ptr("user")},
 				State:     Ptr("closed"),
@@ -172,20 +177,6 @@ func TestArticleService_ConvertIssueToArticle(t *testing.T) {
 			},
 			want: map[string]interface{}{
 				"imageCount": 2,
-			},
-		},
-		{
-			name: "HTML画像付きIssue",
-			issue: &github.Issue{
-				Title:     Ptr("HTML Image Issue"),
-				Body:      Ptr(`<img width="100" alt="test" src="https://example.com/test.png">`),
-				CreatedAt: parseTime("2021-07-01T00:00:00Z"),
-				User:      &github.User{Login: Ptr("user")},
-				State:     Ptr("closed"),
-				Labels:    []*github.Label{},
-			},
-			want: map[string]interface{}{
-				"imageCount": 1,
 			},
 		},
 	}
@@ -228,6 +219,22 @@ func TestArticleService_ConvertIssueToArticle(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestExtractGitHubHostedImages_DeduplicatesURLs(t *testing.T) {
+	content := strings.Join([]string{
+		"![a](https://github.com/user-attachments/assets/11111111-1111-1111-1111-111111111111)",
+		`<img src="https://github.com/user-attachments/assets/11111111-1111-1111-1111-111111111111">`,
+		"https://private-user-images.githubusercontent.com/22222222/33333333-4444-5555-6666-777777777777.png?jwt=token",
+	}, "\n")
+
+	got := extractGitHubHostedImages(content, "2021-01-01_000000")
+
+	require.Len(t, got, 2)
+	assertEqualCmp(t, "https://github.com/user-attachments/assets/11111111-1111-1111-1111-111111111111", got[0].URL)
+	assertEqualCmp(t, 0, got[0].ID)
+	assertEqualCmp(t, "https://private-user-images.githubusercontent.com/22222222/33333333-4444-5555-6666-777777777777.png?jwt=token", got[1].URL)
+	assertEqualCmp(t, 1, got[1].ID)
 }
 
 func TestArticleService_ConvertIssueToArticle_PullRequest(t *testing.T) {


### PR DESCRIPTION
## Summary

This PR changes image detection in issue bodies from Markdown/HTML element parsing to direct collection of known GitHub-hosted attachment URLs.

It also simplifies content replacement by building a replacement map from successfully saved assets and applying it to the article body in one pass.

## Background

The main reason we rewrite image URLs is that content pasted into issues in private repositories can return `404` for users who are not authorized to access the original GitHub-hosted asset.

Because of that, the goal here is not to interpret image syntax itself. The goal is to identify GitHub-hosted attachment URLs that may require authorization, download them, and replace them with public static URLs generated by this tool.

## What Changed

- Removed Markdown image-specific parsing
- Removed HTML `<img>`-specific parsing
- Switched detection to scanning the full issue body for known GitHub-hosted asset URLs
- Limited detection targets to:
  - `github.com/user-attachments/...`
  - `user-images.githubusercontent.com/...`
  - `private-user-images.githubusercontent.com/...`
- Deduplicated identical URLs before downloading assets
- Switched replacement to a single-pass URL replacement using the set of successfully saved assets

## Detection Flow Change

Before:

1. Detect Markdown image syntax such as `![](...)`
2. Detect HTML `<img>` elements
3. Extract image URLs from each syntax form
4. Download the extracted assets
5. Replace URLs in content one by one

After:

1. Scan the full issue body for URL candidates
2. Keep only known GitHub-hosted attachment URLs
3. Deduplicate the collected URLs
4. Download the collected assets
5. Build a replacement map from saved assets
6. Replace matching URLs in content in one pass

```mermaid
flowchart TD
    A[GitHub Issue Body] --> B[Scan full body for URL candidates]
    B --> C{Known GitHub-hosted attachment URL?}
    C -->|No| D[Ignore]
    C -->|Yes| E[Collect URL]
    E --> F[Deduplicate]
    F --> G[Download asset]
    G --> H[Save asset locally]
    H --> I[Add entry to replacement map]
    I --> J[Replace matching URLs in content in one pass]
    J --> K[Rendered article with public asset URLs]
```

## Benefits

- Aligns the implementation with the real requirement: recovering GitHub-hosted private attachments for public content output
- Removes unnecessary coupling to Markdown and HTML image syntax
- Handles the same GitHub-hosted asset URL consistently regardless of where it appears in the body
- Avoids redundant downloads for duplicated URLs

## Scope

This PR does not include general repository asset URLs such as `raw.githubusercontent.com`.

The scope is intentionally limited to GitHub-hosted attachment URLs that are directly related to the private repository access problem.

## Testing

- Added tests for collecting only supported GitHub-hosted asset URLs
- Added tests for deduplicating repeated URLs
- Kept replacement behavior covered by filesystem article save tests
- Ran `go test ./pkg/core ./pkg/config`
