### PR TITLE
fix: log image download authentication failures

### DIFF
--- a/pkg/core/http_assets.go
+++ b/pkg/core/http_assets.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -49,14 +50,25 @@ func (r *HTTPImageRepository) Fetch(ctx context.Context, image *Image) (*ImageAs
 
 // downloadImage downloads an image over HTTP.
 func (r *HTTPImageRepository) downloadImage(ctx context.Context, url string) (io.ReadCloser, string, error) {
-	// Try an authenticated request first.
+	// Try an authenticated request first so private attachments can be fetched.
 	if r.token != "" {
 		if body, contentType, err := r.sendRequest(ctx, url, true); err == nil {
 			return body, contentType, nil
+		} else {
+			r.logger.Warn("authenticated image download failed; retrying without token", "url", url, "error", err)
+
+			body, contentType, fallbackErr := r.sendRequest(ctx, url, false)
+			if fallbackErr == nil {
+				return body, contentType, nil
+			}
+			return nil, "", errors.Join(
+				fmt.Errorf("authenticated request failed: %w", err),
+				fmt.Errorf("unauthenticated fallback failed: %w", fallbackErr),
+			)
 		}
 	}
 
-	// Fall back to an unauthenticated request.
+	// No token was configured, so only an unauthenticated request is possible.
 	return r.sendRequest(ctx, url, false)
 }
 

--- a/pkg/core/http_assets_test.go
+++ b/pkg/core/http_assets_test.go
@@ -1,8 +1,10 @@
 package core
 
 import (
+	"bytes"
 	"context"
 	"io"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -124,6 +126,24 @@ func TestHTTPImageRepository_Download(t *testing.T) {
 		defer asset.Body.Close()
 		assertEqualCmp(t, "token test-token", authHeader)
 	})
+}
+
+func TestHTTPImageRepository_Fetch_ReportsAuthenticatedAndFallbackFailures(t *testing.T) {
+	var logs bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&logs, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	repo := NewHTTPImageRepositoryWithLogger("test-token", logger)
+	_, err := repo.Fetch(context.Background(), NewImage(server.URL, "2021-01-01_000000", 0))
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "authenticated request failed")
+	assert.Contains(t, err.Error(), "unauthenticated fallback failed")
+	assert.Contains(t, logs.String(), "authenticated image download failed; retrying without token")
+	assert.NotContains(t, logs.String(), "test-token")
 }
 
 func TestHTTPImageRepository_Download_InvalidURL(t *testing.T) {


### PR DESCRIPTION
## Summary
- Log a warning when an authenticated image-download request fails before retrying unauthenticated.
- Preserve both the authenticated failure and the fallback failure in the returned error when neither request succeeds.
- Keep the configured token out of logs.

This makes GitHub Actions failures distinguishable: the generated log now shows whether the token-backed request failed and includes each response error (for example, HTTP 404 or an unsupported content type).

## Testing
- `go test ./...`
- `go vet ./...`
- `gofmt` check
- Added regression coverage for an authenticated failure followed by an unauthenticated fallback failure.
