### PR TITLE
fix: write downloaded images atomically

### DIFF
--- a/pkg/core/filesystem_articles.go
+++ b/pkg/core/filesystem_articles.go
@@ -2,6 +2,8 @@ package core
 
 import (
 	"context"
+	"crypto/rand"
+	"encoding/hex"
 	"fmt"
 	"io"
 	"log/slog"
@@ -155,7 +157,7 @@ func (r *FileSystemArticleRepository) saveImage(ctx context.Context, image *Imag
 	}
 
 	fullPath := filepath.Join(imageDir, filename)
-	tempFile, err := os.CreateTemp(imageDir, "."+filename+"-*")
+	tempFile, err := createImageTempFile(imageDir, filename)
 	if err != nil {
 		return "", fmt.Errorf("failed to create temporary image file in %s: %w", imageDir, err)
 	}
@@ -166,9 +168,6 @@ func (r *FileSystemArticleRepository) saveImage(ctx context.Context, image *Imag
 		_ = tempFile.Close()
 		return "", fmt.Errorf("failed to write image to %s: %w", fullPath, err)
 	}
-	if err := tempFile.Chmod(0o644); err != nil {
-		return "", fmt.Errorf("failed to set image file permissions for %s: %w", fullPath, err)
-	}
 	if err := tempFile.Close(); err != nil {
 		return "", fmt.Errorf("failed to close image file %s: %w", fullPath, err)
 	}
@@ -177,6 +176,28 @@ func (r *FileSystemArticleRepository) saveImage(ctx context.Context, image *Imag
 	}
 
 	return filename, nil
+}
+
+func createImageTempFile(directory, filename string) (*os.File, error) {
+	const maxAttempts = 100
+
+	for range maxAttempts {
+		var randomBytes [16]byte
+		if _, err := rand.Read(randomBytes[:]); err != nil {
+			return nil, fmt.Errorf("generate random suffix: %w", err)
+		}
+
+		path := filepath.Join(directory, "."+filename+"-"+hex.EncodeToString(randomBytes[:]))
+		file, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE|os.O_EXCL, 0o666)
+		if err == nil {
+			return file, nil
+		}
+		if !os.IsExist(err) {
+			return nil, err
+		}
+	}
+
+	return nil, fmt.Errorf("could not create a unique temporary file")
 }
 
 func resolveImageFilename(conf config.Config, image *Image, datetime time.Time) string {

--- a/pkg/core/filesystem_articles.go
+++ b/pkg/core/filesystem_articles.go
@@ -166,6 +166,9 @@ func (r *FileSystemArticleRepository) saveImage(ctx context.Context, image *Imag
 		_ = tempFile.Close()
 		return "", fmt.Errorf("failed to write image to %s: %w", fullPath, err)
 	}
+	if err := tempFile.Chmod(0o644); err != nil {
+		return "", fmt.Errorf("failed to set image file permissions for %s: %w", fullPath, err)
+	}
 	if err := tempFile.Close(); err != nil {
 		return "", fmt.Errorf("failed to close image file %s: %w", fullPath, err)
 	}

--- a/pkg/core/filesystem_articles.go
+++ b/pkg/core/filesystem_articles.go
@@ -157,6 +157,15 @@ func (r *FileSystemArticleRepository) saveImage(ctx context.Context, image *Imag
 	}
 
 	fullPath := filepath.Join(imageDir, filename)
+	var existingMode os.FileMode
+	preserveExistingMode := false
+	if info, err := os.Stat(fullPath); err == nil {
+		existingMode = info.Mode().Perm()
+		preserveExistingMode = true
+	} else if !os.IsNotExist(err) {
+		return "", fmt.Errorf("failed to stat existing image file %s: %w", fullPath, err)
+	}
+
 	tempFile, err := createImageTempFile(imageDir)
 	if err != nil {
 		return "", fmt.Errorf("failed to create temporary image file in %s: %w", imageDir, err)
@@ -167,6 +176,11 @@ func (r *FileSystemArticleRepository) saveImage(ctx context.Context, image *Imag
 	if _, err := io.Copy(tempFile, asset.Body); err != nil {
 		_ = tempFile.Close()
 		return "", fmt.Errorf("failed to write image to %s: %w", fullPath, err)
+	}
+	if preserveExistingMode {
+		if err := tempFile.Chmod(existingMode); err != nil {
+			return "", fmt.Errorf("failed to preserve image file permissions for %s: %w", fullPath, err)
+		}
 	}
 	if err := tempFile.Close(); err != nil {
 		return "", fmt.Errorf("failed to close image file %s: %w", fullPath, err)

--- a/pkg/core/filesystem_articles.go
+++ b/pkg/core/filesystem_articles.go
@@ -179,6 +179,7 @@ func (r *FileSystemArticleRepository) saveImage(ctx context.Context, image *Imag
 	}
 	if preserveExistingMode {
 		if err := tempFile.Chmod(existingMode); err != nil {
+			_ = tempFile.Close()
 			return "", fmt.Errorf("failed to preserve image file permissions for %s: %w", fullPath, err)
 		}
 	}

--- a/pkg/core/filesystem_articles.go
+++ b/pkg/core/filesystem_articles.go
@@ -157,7 +157,7 @@ func (r *FileSystemArticleRepository) saveImage(ctx context.Context, image *Imag
 	}
 
 	fullPath := filepath.Join(imageDir, filename)
-	tempFile, err := createImageTempFile(imageDir, filename)
+	tempFile, err := createImageTempFile(imageDir)
 	if err != nil {
 		return "", fmt.Errorf("failed to create temporary image file in %s: %w", imageDir, err)
 	}
@@ -178,7 +178,7 @@ func (r *FileSystemArticleRepository) saveImage(ctx context.Context, image *Imag
 	return filename, nil
 }
 
-func createImageTempFile(directory, filename string) (*os.File, error) {
+func createImageTempFile(directory string) (*os.File, error) {
 	const maxAttempts = 100
 
 	for range maxAttempts {
@@ -187,7 +187,7 @@ func createImageTempFile(directory, filename string) (*os.File, error) {
 			return nil, fmt.Errorf("generate random suffix: %w", err)
 		}
 
-		path := filepath.Join(directory, "."+filename+"-"+hex.EncodeToString(randomBytes[:]))
+		path := filepath.Join(directory, ".gic-image-"+hex.EncodeToString(randomBytes[:]))
 		file, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE|os.O_EXCL, 0o666)
 		if err == nil {
 			return file, nil

--- a/pkg/core/filesystem_articles.go
+++ b/pkg/core/filesystem_articles.go
@@ -155,14 +155,22 @@ func (r *FileSystemArticleRepository) saveImage(ctx context.Context, image *Imag
 	}
 
 	fullPath := filepath.Join(imageDir, filename)
-	file, err := os.Create(fullPath)
+	tempFile, err := os.CreateTemp(imageDir, "."+filename+"-*")
 	if err != nil {
-		return "", fmt.Errorf("failed to create file %s: %w", fullPath, err)
+		return "", fmt.Errorf("failed to create temporary image file in %s: %w", imageDir, err)
 	}
-	defer file.Close()
+	tempPath := tempFile.Name()
+	defer os.Remove(tempPath)
 
-	if _, err := io.Copy(file, asset.Body); err != nil {
+	if _, err := io.Copy(tempFile, asset.Body); err != nil {
+		_ = tempFile.Close()
 		return "", fmt.Errorf("failed to write image to %s: %w", fullPath, err)
+	}
+	if err := tempFile.Close(); err != nil {
+		return "", fmt.Errorf("failed to close image file %s: %w", fullPath, err)
+	}
+	if err := os.Rename(tempPath, fullPath); err != nil {
+		return "", fmt.Errorf("failed to finalize image file %s: %w", fullPath, err)
 	}
 
 	return filename, nil

--- a/pkg/core/filesystem_articles_test.go
+++ b/pkg/core/filesystem_articles_test.go
@@ -61,6 +61,19 @@ func TestFileSystemArticleRepository_SaveImage_RemovesPartialFileOnFailure(t *te
 	assert.True(t, os.IsNotExist(statErr))
 }
 
+func TestFileSystemArticleRepository_SaveImage_UsesReadableFilePermissions(t *testing.T) {
+	tempDir := t.TempDir()
+	conf := *config.NewConfig()
+	conf.Output.Images.Filename = "[:id].png"
+	repo := &FileSystemArticleRepository{imageRepo: &fakeImageRepository{contentType: "image/png", body: "png"}}
+
+	filename, err := repo.saveImage(context.Background(), NewImage("https://example.com/image.png", "", 0), tempDir, conf, time.Now())
+	require.NoError(t, err)
+	info, err := os.Stat(filepath.Join(tempDir, filename))
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0o644), info.Mode().Perm())
+}
+
 func TestFileSystemArticleRepository_Save_RewritesImageURLs(t *testing.T) {
 	tests := []struct {
 		name              string

--- a/pkg/core/filesystem_articles_test.go
+++ b/pkg/core/filesystem_articles_test.go
@@ -81,6 +81,24 @@ func TestFileSystemArticleRepository_SaveImage_RespectsProcessUmask(t *testing.T
 	assert.Equal(t, referenceInfo.Mode().Perm(), info.Mode().Perm())
 }
 
+func TestFileSystemArticleRepository_SaveImage_PreservesExistingFilePermissions(t *testing.T) {
+	tempDir := t.TempDir()
+	filename := "image.png"
+	fullPath := filepath.Join(tempDir, filename)
+	require.NoError(t, os.WriteFile(fullPath, []byte("old"), 0o600))
+	require.NoError(t, os.Chmod(fullPath, 0o600))
+
+	conf := *config.NewConfig()
+	conf.Output.Images.Filename = filename
+	repo := &FileSystemArticleRepository{imageRepo: &fakeImageRepository{contentType: "image/png", body: "new"}}
+
+	_, err := repo.saveImage(context.Background(), NewImage("https://example.com/image.png", "", 0), tempDir, conf, time.Now())
+	require.NoError(t, err)
+	info, err := os.Stat(fullPath)
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0o600), info.Mode().Perm())
+}
+
 func TestFileSystemArticleRepository_SaveImage_SupportsMaximumLengthFilename(t *testing.T) {
 	tempDir := t.TempDir()
 	filename := strings.Repeat("a", 251) + ".png"

--- a/pkg/core/filesystem_articles_test.go
+++ b/pkg/core/filesystem_articles_test.go
@@ -61,8 +61,15 @@ func TestFileSystemArticleRepository_SaveImage_RemovesPartialFileOnFailure(t *te
 	assert.True(t, os.IsNotExist(statErr))
 }
 
-func TestFileSystemArticleRepository_SaveImage_UsesReadableFilePermissions(t *testing.T) {
+func TestFileSystemArticleRepository_SaveImage_RespectsProcessUmask(t *testing.T) {
 	tempDir := t.TempDir()
+	referencePath := filepath.Join(tempDir, "reference")
+	reference, err := os.OpenFile(referencePath, os.O_RDWR|os.O_CREATE|os.O_EXCL, 0o666)
+	require.NoError(t, err)
+	require.NoError(t, reference.Close())
+	referenceInfo, err := os.Stat(referencePath)
+	require.NoError(t, err)
+
 	conf := *config.NewConfig()
 	conf.Output.Images.Filename = "[:id].png"
 	repo := &FileSystemArticleRepository{imageRepo: &fakeImageRepository{contentType: "image/png", body: "png"}}
@@ -71,7 +78,7 @@ func TestFileSystemArticleRepository_SaveImage_UsesReadableFilePermissions(t *te
 	require.NoError(t, err)
 	info, err := os.Stat(filepath.Join(tempDir, filename))
 	require.NoError(t, err)
-	assert.Equal(t, os.FileMode(0o644), info.Mode().Perm())
+	assert.Equal(t, referenceInfo.Mode().Perm(), info.Mode().Perm())
 }
 
 func TestFileSystemArticleRepository_Save_RewritesImageURLs(t *testing.T) {

--- a/pkg/core/filesystem_articles_test.go
+++ b/pkg/core/filesystem_articles_test.go
@@ -81,6 +81,20 @@ func TestFileSystemArticleRepository_SaveImage_RespectsProcessUmask(t *testing.T
 	assert.Equal(t, referenceInfo.Mode().Perm(), info.Mode().Perm())
 }
 
+func TestFileSystemArticleRepository_SaveImage_SupportsMaximumLengthFilename(t *testing.T) {
+	tempDir := t.TempDir()
+	filename := strings.Repeat("a", 251) + ".png"
+	conf := *config.NewConfig()
+	conf.Output.Images.Filename = filename
+	repo := &FileSystemArticleRepository{imageRepo: &fakeImageRepository{contentType: "image/png", body: "png"}}
+
+	savedFilename, err := repo.saveImage(context.Background(), NewImage("https://example.com/image.png", "", 0), tempDir, conf, time.Now())
+	require.NoError(t, err)
+	assert.Equal(t, filename, savedFilename)
+	_, err = os.Stat(filepath.Join(tempDir, savedFilename))
+	require.NoError(t, err)
+}
+
 func TestFileSystemArticleRepository_Save_RewritesImageURLs(t *testing.T) {
 	tests := []struct {
 		name              string

--- a/pkg/core/filesystem_articles_test.go
+++ b/pkg/core/filesystem_articles_test.go
@@ -27,6 +27,40 @@ func (r *fakeImageRepository) Fetch(ctx context.Context, image *Image) (*ImageAs
 	}, nil
 }
 
+type failingImageRepository struct{}
+
+func (failingImageRepository) Fetch(context.Context, *Image) (*ImageAsset, error) {
+	return &ImageAsset{
+		Body:        io.NopCloser(&failingReader{}),
+		ContentType: "image/png",
+	}, nil
+}
+
+type failingReader struct {
+	read bool
+}
+
+func (r *failingReader) Read(p []byte) (int, error) {
+	if r.read {
+		return 0, assert.AnError
+	}
+	r.read = true
+	copy(p, "partial")
+	return len("partial"), nil
+}
+
+func TestFileSystemArticleRepository_SaveImage_RemovesPartialFileOnFailure(t *testing.T) {
+	tempDir := t.TempDir()
+	conf := *config.NewConfig()
+	conf.Output.Images.Filename = "[:id].png"
+	repo := &FileSystemArticleRepository{imageRepo: failingImageRepository{}}
+
+	_, err := repo.saveImage(context.Background(), NewImage("https://example.com/image.png", "", 0), tempDir, conf, time.Now())
+	require.Error(t, err)
+	_, statErr := os.Stat(filepath.Join(tempDir, "0.png"))
+	assert.True(t, os.IsNotExist(statErr))
+}
+
 func TestFileSystemArticleRepository_Save_RewritesImageURLs(t *testing.T) {
 	tests := []struct {
 		name              string


### PR DESCRIPTION
## Summary
- write each downloaded image to a temporary file
- rename it into the final output path only after copying and closing succeed
- remove the temporary file when the download stream fails

## Why
A failed or interrupted image download previously left a partial file at the final asset path. That could make a generated site reference a corrupt image.

## Tests
- `TMPDIR="$PWD/.tmp/go-build" go test ./pkg/core`
- `TMPDIR="$PWD/.tmp/go-build" go vet ./pkg/core`
