### PR TITLE
fix: enforce HTTPS for token-bearing image requests

### DIFF
--- a/pkg/core/http_assets.go
+++ b/pkg/core/http_assets.go
@@ -14,6 +14,7 @@ import (
 )
 
 const defaultHTTPTimeout = 30
+const maxRedirects = 10
 
 // HTTPImageRepository downloads images over HTTP.
 type HTTPImageRepository struct {
@@ -111,7 +112,7 @@ func (r *HTTPImageRepository) clientWithRedirectGuard() *http.Client {
 		if !isHTTPS(redirectReq.URL.String()) {
 			redirectReq.Header.Del("Authorization")
 		}
-		if len(via) >= 10 {
+		if len(via) >= maxRedirects {
 			return errors.New("stopped after 10 redirects")
 		}
 		return nil

--- a/pkg/core/http_assets.go
+++ b/pkg/core/http_assets.go
@@ -113,7 +113,7 @@ func (r *HTTPImageRepository) clientWithRedirectGuard() *http.Client {
 			redirectReq.Header.Del("Authorization")
 		}
 		if len(via) >= maxRedirects {
-			return errors.New("stopped after 10 redirects")
+			return fmt.Errorf("stopped after %d redirects", maxRedirects)
 		}
 		return nil
 	}

--- a/pkg/core/http_assets.go
+++ b/pkg/core/http_assets.go
@@ -103,11 +103,14 @@ func (r *HTTPImageRepository) sendRequest(ctx context.Context, url string, inclu
 }
 
 // clientWithRedirectGuard returns a copy of the HTTP client that strips the
-// Authorization header on every redirect to prevent token leakage.
+// Authorization header when redirecting from HTTPS to HTTP to prevent token
+// leakage. Redirects to other HTTPS URLs retain the token.
 func (r *HTTPImageRepository) clientWithRedirectGuard() *http.Client {
 	c := *r.client
 	c.CheckRedirect = func(redirectReq *http.Request, via []*http.Request) error {
-		redirectReq.Header.Del("Authorization")
+		if !isHTTPS(redirectReq.URL.String()) {
+			redirectReq.Header.Del("Authorization")
+		}
 		if len(via) >= 10 {
 			return errors.New("stopped after 10 redirects")
 		}

--- a/pkg/core/http_assets.go
+++ b/pkg/core/http_assets.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 	"mime"
 	"net/http"
+	"net/url"
 	"strings"
 	"time"
 )
@@ -49,15 +50,15 @@ func (r *HTTPImageRepository) Fetch(ctx context.Context, image *Image) (*ImageAs
 }
 
 // downloadImage downloads an image over HTTP.
-func (r *HTTPImageRepository) downloadImage(ctx context.Context, url string) (io.ReadCloser, string, error) {
-	// Try an authenticated request first so private attachments can be fetched.
-	if r.token != "" {
-		if body, contentType, err := r.sendRequest(ctx, url, true); err == nil {
+func (r *HTTPImageRepository) downloadImage(ctx context.Context, imageURL string) (io.ReadCloser, string, error) {
+	// Only send the token over HTTPS to prevent leaking credentials.
+	if r.token != "" && isHTTPS(imageURL) {
+		if body, contentType, err := r.sendRequest(ctx, imageURL, true); err == nil {
 			return body, contentType, nil
 		} else {
-			r.logger.Warn("authenticated image download failed; retrying without token", "url", url, "error", err)
+			r.logger.Warn("authenticated image download failed; retrying without token", "url", imageURL, "error", err)
 
-			body, contentType, fallbackErr := r.sendRequest(ctx, url, false)
+			body, contentType, fallbackErr := r.sendRequest(ctx, imageURL, false)
 			if fallbackErr == nil {
 				return body, contentType, nil
 			}
@@ -68,8 +69,8 @@ func (r *HTTPImageRepository) downloadImage(ctx context.Context, url string) (io
 		}
 	}
 
-	// No token was configured, so only an unauthenticated request is possible.
-	return r.sendRequest(ctx, url, false)
+	// No token was configured or the URL is not HTTPS — only an unauthenticated request is possible.
+	return r.sendRequest(ctx, imageURL, false)
 }
 
 // sendRequest sends an HTTP request.
@@ -79,11 +80,14 @@ func (r *HTTPImageRepository) sendRequest(ctx context.Context, url string, inclu
 		return nil, "", err
 	}
 
+	client := r.client
 	if includeToken && r.token != "" {
 		req.Header.Set("Authorization", "token "+r.token)
+		// Prevent the token from leaking to a redirect destination.
+		client = r.clientWithRedirectGuard()
 	}
 
-	resp, err := r.client.Do(req)
+	resp, err := client.Do(req)
 	if err != nil {
 		return nil, "", err
 	}
@@ -96,6 +100,28 @@ func (r *HTTPImageRepository) sendRequest(ctx context.Context, url string, inclu
 	}
 
 	return resp.Body, contentType, nil
+}
+
+// clientWithRedirectGuard returns a copy of the HTTP client that strips the
+// Authorization header on every redirect to prevent token leakage.
+func (r *HTTPImageRepository) clientWithRedirectGuard() *http.Client {
+	c := *r.client
+	c.CheckRedirect = func(redirectReq *http.Request, via []*http.Request) error {
+		redirectReq.Header.Del("Authorization")
+		if len(via) >= 10 {
+			return errors.New("stopped after 10 redirects")
+		}
+		return nil
+	}
+	return &c
+}
+
+func isHTTPS(rawURL string) bool {
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		return false
+	}
+	return strings.EqualFold(parsed.Scheme, "https")
 }
 
 func normalizeContentType(value string) string {

--- a/pkg/core/http_assets_test.go
+++ b/pkg/core/http_assets_test.go
@@ -168,6 +168,30 @@ func TestHTTPImageRepository_Download(t *testing.T) {
 		assert.Equal(t, "token test-token", httpsAuthHeader)
 		assert.Empty(t, httpAuthHeader)
 	})
+
+	t.Run("retains token on redirect to another HTTPS URL", func(t *testing.T) {
+		var initialAuthHeader string
+		var redirectedAuthHeader string
+		server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path == "/redirect" {
+				initialAuthHeader = r.Header.Get("Authorization")
+				http.Redirect(w, r, "/image", http.StatusFound)
+				return
+			}
+			redirectedAuthHeader = r.Header.Get("Authorization")
+			w.Header().Set("Content-Type", "image/png")
+			_, _ = w.Write([]byte("PNG"))
+		}))
+		defer server.Close()
+
+		repo := NewHTTPImageRepository("test-token").(*HTTPImageRepository)
+		repo.client = server.Client()
+		asset, err := repo.Fetch(context.Background(), NewImage(server.URL+"/redirect", "2021-01-01_000000", 0))
+		assert.NoError(t, err)
+		defer asset.Body.Close()
+		assert.Equal(t, "token test-token", initialAuthHeader)
+		assert.Equal(t, "token test-token", redirectedAuthHeader)
+	})
 }
 
 func TestHTTPImageRepository_Fetch_ReportsAuthenticatedAndFallbackFailures(t *testing.T) {

--- a/pkg/core/http_assets_test.go
+++ b/pkg/core/http_assets_test.go
@@ -106,7 +106,7 @@ func TestHTTPImageRepository_Download(t *testing.T) {
 
 	t.Run("request with token", func(t *testing.T) {
 		var authHeader string
-		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			authHeader = r.Header.Get("Authorization")
 			w.Header().Set("Content-Type", "image/png")
 			w.WriteHeader(http.StatusOK)
@@ -114,7 +114,8 @@ func TestHTTPImageRepository_Download(t *testing.T) {
 		}))
 		defer server.Close()
 
-		repo := NewHTTPImageRepository("test-token")
+		repo := NewHTTPImageRepository("test-token").(*HTTPImageRepository)
+		repo.client = server.Client()
 		image := &Image{
 			URL:  server.URL,
 			Time: "2021-01-01_000000",
@@ -126,17 +127,59 @@ func TestHTTPImageRepository_Download(t *testing.T) {
 		defer asset.Body.Close()
 		assertEqualCmp(t, "token test-token", authHeader)
 	})
+
+	t.Run("does not send token to HTTP URL", func(t *testing.T) {
+		var authHeader string
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			authHeader = r.Header.Get("Authorization")
+			w.Header().Set("Content-Type", "image/png")
+			_, _ = w.Write([]byte("PNG"))
+		}))
+		defer server.Close()
+
+		repo := NewHTTPImageRepository("test-token")
+		asset, err := repo.Fetch(context.Background(), NewImage(server.URL, "2021-01-01_000000", 0))
+		assert.NoError(t, err)
+		defer asset.Body.Close()
+		assert.Empty(t, authHeader)
+	})
+
+	t.Run("strips token on redirect from HTTPS to HTTP", func(t *testing.T) {
+		var httpsAuthHeader string
+		var httpAuthHeader string
+		httpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			httpAuthHeader = r.Header.Get("Authorization")
+			w.Header().Set("Content-Type", "image/png")
+			_, _ = w.Write([]byte("PNG"))
+		}))
+		defer httpServer.Close()
+
+		httpsServer := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			httpsAuthHeader = r.Header.Get("Authorization")
+			http.Redirect(w, r, httpServer.URL, http.StatusFound)
+		}))
+		defer httpsServer.Close()
+
+		repo := NewHTTPImageRepository("test-token").(*HTTPImageRepository)
+		repo.client = httpsServer.Client()
+		asset, err := repo.Fetch(context.Background(), NewImage(httpsServer.URL, "2021-01-01_000000", 0))
+		assert.NoError(t, err)
+		defer asset.Body.Close()
+		assert.Equal(t, "token test-token", httpsAuthHeader)
+		assert.Empty(t, httpAuthHeader)
+	})
 }
 
 func TestHTTPImageRepository_Fetch_ReportsAuthenticatedAndFallbackFailures(t *testing.T) {
 	var logs bytes.Buffer
 	logger := slog.New(slog.NewTextHandler(&logs, &slog.HandlerOptions{Level: slog.LevelDebug}))
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusNotFound)
 	}))
 	defer server.Close()
 
-	repo := NewHTTPImageRepositoryWithLogger("test-token", logger)
+	repo := NewHTTPImageRepositoryWithLogger("test-token", logger).(*HTTPImageRepository)
+	repo.client = server.Client()
 	_, err := repo.Fetch(context.Background(), NewImage(server.URL, "2021-01-01_000000", 0))
 
 	assert.Error(t, err)


### PR DESCRIPTION
## Summary

Token-bearing image requests are now restricted to HTTPS only. HTTP URLs will never receive the token, and redirects from HTTPS to HTTP will strip the Authorization header while HTTPS-to-HTTPS redirects retain it.

## Changes

- Add `isHTTPS()` helper to check URL scheme
- Gate authenticated requests on `isHTTPS()` in `downloadImage()`
- Add `clientWithRedirectGuard()` — strips `Authorization` only when redirecting to a non-HTTPS destination
- Extract `maxRedirects` constant
- Tests: token not sent to HTTP URLs
- Tests: token stripped on HTTPS → HTTP redirect
- Tests: token retained on HTTPS → HTTPS redirect
- Update existing tests to use TLS servers where tokens are expected

## Verification

```
go test ./...
go vet ./...
```

All pass.