### PR TITLE
docs: note that private attachment images require a classic PAT

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,9 @@ Run this application with your GitHub Access Token
 $ github-issue-cms generate --token="YOUR_GITHUB_TOKEN"
 ```
 
+> [!NOTE]
+> If your issues have images attached via drag-and-drop (`https://github.com/user-attachments/assets/...`) in a **private** repository, use a **classic** Personal Access Token. Fine-grained PATs and GitHub App installation tokens (including the Actions-provided `GITHUB_TOKEN`) are not accepted by GitHub's attachment download endpoint and will cause image downloads to fail with a 404.
+
 If your repository has issues and attached images, they will be exported like this tree.
 
 These output paths are configurable, so you can adapt them to your site or build pipeline.
@@ -74,6 +77,9 @@ $ tree --dirsfirst
 ### 4. (Optional) Auto commit with GitHub Actions
 
 GitHub Actions provides a built-in `GITHUB_TOKEN`, so you do not need to create a separate repository secret for this workflow.
+
+> [!NOTE]
+> The built-in `GITHUB_TOKEN` is an installation token, so for a **private** repository it cannot download images attached via drag-and-drop (see the note above). If you need those images, use a classic PAT stored as a repository secret instead.
 
 Next, write this workflow with the permissions required to read issues and commit generated files.
 

--- a/docs/content/quickstart.ja.md
+++ b/docs/content/quickstart.ja.md
@@ -56,6 +56,10 @@ output:
 $ github-issue-cms generate --token="<YOUR_GITHUB_ACCESS_TOKEN>"
 ```
 
+{{% callout type="warning" %}}
+プライベートリポジトリで、ドラッグ&ドロップで添付した画像（`https://github.com/user-attachments/assets/...`）を利用している場合は、**Classic** な Personal Access Token を使用してください。Fine-grained PAT や GitHub App のインストールトークン（GitHub Actions が提供する `GITHUB_TOKEN` を含む）は GitHub の添付ファイルダウンロードエンドポイントで受け付けられず、画像のダウンロードが 404 で失敗します。
+{{% /callout %}}
+
 もし、Issueに添付画像がある場合は以下のように出力されます。
 
 ```shell

--- a/docs/content/quickstart.md
+++ b/docs/content/quickstart.md
@@ -56,6 +56,10 @@ Run the following command to convert all issues from the target repository to Ma
 $ github-issue-cms generate --token="<YOUR_GITHUB_ACCESS_TOKEN>"
 ```
 
+{{% callout type="warning" %}}
+If your issues have images attached via drag-and-drop (`https://github.com/user-attachments/assets/...`) in a **private** repository, use a **classic** Personal Access Token. Fine-grained PATs and GitHub App installation tokens (including the `GITHUB_TOKEN` provided by GitHub Actions) are not accepted by GitHub's attachment download endpoint, and image downloads will fail with a 404.
+{{% /callout %}}
+
 If issues have attached images, the output will be as follows:
 
 ```shell


### PR DESCRIPTION
## Summary
- README and quickstart docs (en/ja) now note that images attached via drag-and-drop in a private repo (`https://github.com/user-attachments/assets/...`) can only be downloaded with a classic Personal Access Token — fine-grained PATs and GitHub App installation tokens (including the Actions-provided `GITHUB_TOKEN`) return 404 from GitHub's attachment endpoint.

## Test plan
- [x] Docs-only change, no code affected