### PR TITLE
ci: reuse existing draft release on retry

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -53,3 +53,6 @@ release:
     owner: rokuosan
     name: github-issue-cms
   prerelease: auto
+  # Reuse a leftover draft from a previously failed run instead of creating
+  # a new one each retry, so failed drafts don't pile up.
+  use_existing_draft: true


### PR DESCRIPTION
## Summary
- Sets `use_existing_draft: true` in `.goreleaser.yaml` so a retried release run reuses the leftover draft from a failed run instead of creating a new one.
- Relevant while preparing to enable GitHub's Immutable Releases: GoReleaser already creates the release as a draft, uploads all artifacts, then publishes — matching the draft→upload→publish order immutable releases require. This change just prevents failed-run drafts from accumulating.

## Test plan
- [ ] Push a tag and confirm `generate` release workflow still publishes normally
- [ ] Simulate a failed run (e.g. cancel mid-upload) and confirm the retry reuses the same draft rather than creating a second one