### PR TITLE
ci: run OGP renderer integration test

### DIFF
--- a/.github/workflows/ci-golang.yaml
+++ b/.github/workflows/ci-golang.yaml
@@ -45,3 +45,8 @@ jobs:
           go-version-file: go.mod
       - name: test
         run: go test -v ./...
+      - name: OGP render integration test
+        env:
+          GIC_CHROMIUM_BIN: /usr/bin/google-chrome
+          GIC_INTEGRATION_TEST: "1"
+        run: go test -v ./pkg/ogimage -run '^TestRenderIntegration$'

--- a/.github/workflows/ci-golang.yaml
+++ b/.github/workflows/ci-golang.yaml
@@ -44,9 +44,7 @@ jobs:
         with:
           go-version-file: go.mod
       - name: test
-        run: go test -v ./...
-      - name: OGP render integration test
         env:
           GIC_CHROMIUM_BIN: /usr/bin/google-chrome
           GIC_INTEGRATION_TEST: "1"
-        run: go test -v ./pkg/ogimage -run '^TestRenderIntegration$'
+        run: go test -v ./...

--- a/pkg/ogimage/ogimage_test.go
+++ b/pkg/ogimage/ogimage_test.go
@@ -125,11 +125,13 @@ func TestResolveChromiumBin(t *testing.T) {
 	})
 
 	t.Run("falls back to browserBin", func(t *testing.T) {
+		t.Setenv("GIC_CHROMIUM_BIN", "")
 		r := &Renderer{browserBin: "/usr/bin/chrome"}
 		assert.Equal(t, "/usr/bin/chrome", r.resolveChromiumBin())
 	})
 
 	t.Run("empty when neither is set", func(t *testing.T) {
+		t.Setenv("GIC_CHROMIUM_BIN", "")
 		r := &Renderer{}
 		assert.Equal(t, "", r.resolveChromiumBin())
 	})


### PR DESCRIPTION
## Summary
- Run the existing real-Chromium OGP renderer test in CI.
- Use the hosted runner Google Chrome via `GIC_CHROMIUM_BIN`.

## Validation
- `go test ./pkg/ogimage -run "^TestRenderIntegration$" -count=1 -v` (skipped locally because Chromium is unavailable)
- GitHub Actions will execute the real render.

Part of #21
