### PR TITLE
perf(ogimage): reuse browser during generation

### DIFF
--- a/cmd/cli/subcommand/generate.go
+++ b/cmd/cli/subcommand/generate.go
@@ -82,7 +82,12 @@ func runGenerate(cmd *cobra.Command, githubToken string, withOGImage bool) error
 		if err != nil {
 			return fmt.Errorf("failed to create OGP renderer: %w", err)
 		}
+		defer renderer.Close()
 		generator.SetOnArticleSaved(func(article *core.Article) error {
+			if err := renderer.Open(cmd.Context()); err != nil {
+				ogpFail++
+				return fmt.Errorf("open OGP renderer: %w", err)
+			}
 			err := generateOGPForArticle(cmd, conf, renderer, article)
 			if err != nil {
 				ogpFail++

--- a/pkg/ogimage/ogimage_test.go
+++ b/pkg/ogimage/ogimage_test.go
@@ -157,6 +157,9 @@ func TestRenderIntegration(t *testing.T) {
 
 	r, err := NewRenderer("")
 	require.NoError(t, err)
+	require.NoError(t, r.Open(t.Context()))
+	t.Cleanup(r.Close)
+	browser := r.browser
 
 	data := OGPData{
 		Title:    "Integration Test Article",
@@ -166,12 +169,15 @@ func TestRenderIntegration(t *testing.T) {
 		Tags:     []string{"go", "integration"},
 	}
 
-	jpeg, err := r.Render(t.Context(), data)
-	require.NoError(t, err)
-	require.NotEmpty(t, jpeg)
+	for range 2 {
+		jpeg, err := r.Render(t.Context(), data)
+		require.NoError(t, err)
+		require.NotEmpty(t, jpeg)
 
-	// JPEG files start with FF D8 FF.
-	assert.Equal(t, byte(0xFF), jpeg[0])
-	assert.Equal(t, byte(0xD8), jpeg[1])
-	assert.Equal(t, byte(0xFF), jpeg[2])
+		// JPEG files start with FF D8 FF.
+		assert.Equal(t, byte(0xFF), jpeg[0])
+		assert.Equal(t, byte(0xD8), jpeg[1])
+		assert.Equal(t, byte(0xFF), jpeg[2])
+		assert.Same(t, browser, r.browser)
+	}
 }

--- a/pkg/ogimage/renderer.go
+++ b/pkg/ogimage/renderer.go
@@ -29,6 +29,7 @@ type Renderer struct {
 	tmpl       *template.Template
 	browserBin string
 	tmplDir    string // directory of custom template (empty for embedded)
+	browser    *rod.Browser
 }
 
 // NewRenderer creates a Renderer using the embedded default template.
@@ -62,8 +63,32 @@ func NewRendererWithTemplate(tmplPath string, browserBin string) (*Renderer, err
 	}, nil
 }
 
+// Open starts a browser that subsequent Render calls reuse. Call Close when the
+// renderer is no longer needed. Render without Open remains self-contained.
+func (r *Renderer) Open(ctx context.Context) error {
+	if r.browser != nil {
+		return nil
+	}
+
+	browser, err := r.launchBrowser(ctx)
+	if err != nil {
+		return fmt.Errorf("ogimage: open browser: %w", err)
+	}
+	r.browser = browser
+	return nil
+}
+
+// Close closes a browser opened with Open. It is safe to call more than once.
+func (r *Renderer) Close() {
+	if r.browser == nil {
+		return
+	}
+	closeBrowser(r.browser)
+	r.browser = nil
+}
+
 // Render executes the template with the given data, opens a headless browser
-// page, and captures a 1200×630 JPEG screenshot.
+// when Open has not been called, and captures a 1200×630 JPEG screenshot.
 func (r *Renderer) Render(ctx context.Context, data OGPData) ([]byte, error) {
 	// Check context before launching expensive browser process.
 	if err := ctx.Err(); err != nil {
@@ -75,11 +100,15 @@ func (r *Renderer) Render(ctx context.Context, data OGPData) ([]byte, error) {
 		return nil, err
 	}
 
-	browser, err := r.launchBrowser(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("ogimage: launch browser: %w", err)
+	browser := r.browser
+	temporaryBrowser := browser == nil
+	if temporaryBrowser {
+		browser, err = r.launchBrowser(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("ogimage: launch browser: %w", err)
+		}
+		defer closeBrowser(browser)
 	}
-	defer closeBrowser(browser)
 
 	pageURL := "about:blank"
 	if r.tmplDir != "" {


### PR DESCRIPTION
## Summary
- Keep one Chromium process for all OGP images in a `generate --with-ogimage` run.
- Retain self-contained `Renderer.Render` behavior for direct callers.
- Extend the browser integration test to render twice through the same open renderer.

## Validation
- `go test ./...`
- `go vet ./...`
- `golangci-lint run ./...`

## Dependency
- #164 adds the real-Chromium CI step. Once it is merged, this PR receives that runtime check.

Part of #21
