### PR TITLE
Filter issue selection labels from OGP tags

### DIFF
--- a/cmd/cli/subcommand/generate.go
+++ b/cmd/cli/subcommand/generate.go
@@ -137,7 +137,7 @@ func generateOGPForArticle(cmd *cobra.Command, conf config.Config, renderer *ogi
 	// rendered values, not the original GitHub issue metadata.
 	rendered := article.Clone()
 	core.ApplyFrontMatterOverrides(rendered, rendered.FrontMatter.Values())
-	data := articleToOGPData(rendered)
+	data := articleToOGPData(rendered, conf)
 
 	jpeg, err := renderer.Render(cmd.Context(), data)
 	if err != nil {

--- a/cmd/cli/subcommand/ogimage.go
+++ b/cmd/cli/subcommand/ogimage.go
@@ -66,7 +66,7 @@ func runOGCImage(cmd *cobra.Command, markdownFile, templateFile string) error {
 	}
 
 	// Convert Article to OGPData.
-	data := articleToOGPData(article)
+	data := articleToOGPData(article, conf)
 
 	// Create renderer.
 	var renderer *ogimage.Renderer
@@ -108,10 +108,12 @@ func runOGCImage(cmd *cobra.Command, markdownFile, templateFile string) error {
 
 // articleToOGPData converts a core.Article to ogimage.OGPData.
 // Returns zero-value OGPData if article is nil.
-func articleToOGPData(article *core.Article) ogimage.OGPData {
+func articleToOGPData(article *core.Article, conf config.Config) ogimage.OGPData {
 	if article == nil {
 		return ogimage.OGPData{}
 	}
+	article = article.Clone()
+	core.FilterArticleTags(article, conf)
 	return ogimage.OGPData{
 		Title:    article.Title,
 		Author:   article.Author,

--- a/cmd/cli/subcommand/ogimage_test.go
+++ b/cmd/cli/subcommand/ogimage_test.go
@@ -68,16 +68,19 @@ func TestArticleToOGPData(t *testing.T) {
 		Author:   "alice",
 		Date:     "2024-01-15T10:30:00Z",
 		Category: "tech",
-		Tags:     []string{"go", "testing"},
+		Tags:     []string{"published", "go", "testing"},
 	}
 
-	data := articleToOGPData(article)
+	conf := *config.NewConfig()
+	conf.GitHub.Labels = []string{"published"}
+	data := articleToOGPData(article, conf)
 
 	assert.Equal(t, "Test Title", data.Title)
 	assert.Equal(t, "alice", data.Author)
 	assert.Equal(t, "2024-01-15", data.Date) // Formatted
 	assert.Equal(t, "tech", data.Category)
 	assert.Equal(t, []string{"go", "testing"}, data.Tags)
+	assert.Equal(t, []string{"published", "go", "testing"}, article.Tags)
 }
 
 func TestArticleToOGPData_EmptyFields(t *testing.T) {
@@ -85,7 +88,7 @@ func TestArticleToOGPData_EmptyFields(t *testing.T) {
 		Title: "Only Title",
 	}
 
-	data := articleToOGPData(article)
+	data := articleToOGPData(article, *config.NewConfig())
 
 	assert.Equal(t, "Only Title", data.Title)
 	assert.Equal(t, "", data.Author)
@@ -172,7 +175,7 @@ This is the article body.`
 	assert.Equal(t, "testuser", article.Author)
 
 	// Convert to OGPData.
-	data := articleToOGPData(article)
+	data := articleToOGPData(article, *config.NewConfig())
 	assert.Equal(t, "Integration Test", data.Title)
 
 	// Render using the ogimage package (requires Chromium).

--- a/pkg/core/filesystem_articles.go
+++ b/pkg/core/filesystem_articles.go
@@ -50,7 +50,10 @@ func (r *FileSystemArticleRepository) Save(ctx context.Context, article *Article
 	}
 
 	rendered := article.Clone()
-	applyFrontMatterOverrides(rendered, rendered.FrontMatter.Values())
+	extra := rendered.FrontMatter.Values()
+	applyFrontMatterOverrides(rendered, extra)
+	rendered.FrontMatter = NewFrontMatter(extra)
+	FilterArticleTags(rendered, conf)
 
 	datetime, err := rendered.ParseDateTime()
 	if err != nil {

--- a/pkg/core/filesystem_articles_test.go
+++ b/pkg/core/filesystem_articles_test.go
@@ -218,6 +218,28 @@ func TestFileSystemArticleRepository_Save_RewritesImageURLs(t *testing.T) {
 	}
 }
 
+func TestFileSystemArticleRepository_Save_FiltersIssueSelectionLabelsFromFrontMatterTags(t *testing.T) {
+	tempDir := t.TempDir()
+	conf := *config.NewConfig()
+	conf.GitHub.Labels = []string{"published"}
+	conf.Output.Articles.Directory = tempDir
+	conf.Output.Articles.Filename = "article.md"
+
+	repo := &FileSystemArticleRepository{renderer: NewHugoArticleRenderer()}
+	article := &Article{
+		Title:       "Title",
+		Date:        "2021-01-01T00:00:00Z",
+		Tags:        []string{"published"},
+		FrontMatter: NewFrontMatter(map[string]any{"tags": []string{"published", "go"}}),
+	}
+
+	require.NoError(t, repo.Save(context.Background(), article, conf))
+	data, err := os.ReadFile(filepath.Join(tempDir, "article.md"))
+	require.NoError(t, err)
+	assert.Contains(t, string(data), "go")
+	assert.NotContains(t, string(data), "published")
+}
+
 func TestFileSystemArticleRepository_Save_UsesFrontMatterDateForOutputPaths(t *testing.T) {
 	tempDir := t.TempDir()
 

--- a/pkg/core/issue_articles.go
+++ b/pkg/core/issue_articles.go
@@ -77,22 +77,11 @@ func (s *ArticleService) ConvertIssueToArticle(issue *github.Issue) *Article {
 	images := extractTargetImages(content, time, s.config.Output.Images.TargetURLs())
 
 	var tags []string
-	excludedLabels := map[string]struct{}{}
-	if s.config.GitHub != nil {
-		excludedLabels = make(map[string]struct{}, len(s.config.GitHub.Labels))
-		for _, label := range s.config.GitHub.Labels {
-			excludedLabels[label] = struct{}{}
-		}
-	}
 	for _, label := range issue.Labels {
-		name := label.GetName()
-		if _, ok := excludedLabels[name]; ok {
-			continue
-		}
-		tags = append(tags, name)
+		tags = append(tags, label.GetName())
 	}
 
-	return &Article{
+	article := &Article{
 		Author:      issue.GetUser().GetLogin(),
 		Title:       issue.GetTitle(),
 		Date:        issue.GetCreatedAt().Format("2006-01-02T15:04:05Z"),
@@ -104,6 +93,27 @@ func (s *ArticleService) ConvertIssueToArticle(issue *github.Issue) *Article {
 		Key:         time,
 		Images:      images,
 	}
+	FilterArticleTags(article, s.config)
+	return article
+}
+
+// FilterArticleTags removes labels used to select issues from article tags.
+func FilterArticleTags(article *Article, conf config.Config) {
+	if article == nil || conf.GitHub == nil || len(article.Tags) == 0 || len(conf.GitHub.Labels) == 0 {
+		return
+	}
+
+	excluded := make(map[string]struct{}, len(conf.GitHub.Labels))
+	for _, label := range conf.GitHub.Labels {
+		excluded[label] = struct{}{}
+	}
+	filtered := article.Tags[:0]
+	for _, tag := range article.Tags {
+		if _, ok := excluded[tag]; !ok {
+			filtered = append(filtered, tag)
+		}
+	}
+	article.Tags = filtered
 }
 
 func extractTargetImages(content string, time string, targetURLs []string) []*Image {


### PR DESCRIPTION
## Summary

- Centralize removal of issue-selection labels from article tags.
- Apply the final tag filtering to Markdown output and OGP data.

## Root cause

Front matter tag overrides were reapplied while saving Markdown, allowing selection labels to reappear. OGP generation did not share the final filtering path.

## Validation

- `go test ./...`
