### PR TITLE
feat(ogimage): add live template preview server

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,18 @@ $ github-issue-cms generate --token="YOUR_GITHUB_TOKEN"
 > [!NOTE]
 > If your issues have images attached via drag-and-drop (`https://github.com/user-attachments/assets/...`) in a **private** repository, use a **classic** Personal Access Token. Fine-grained PATs and GitHub App installation tokens (including the Actions-provided `GITHUB_TOKEN`) are not accepted by GitHub's attachment download endpoint and will cause image downloads to fail with a 404.
 
+### Preview an OGP template
+
+Use the live preview server while editing a custom OGP template:
+
+```bash
+$ github-issue-cms ogimage preview ogp.html
+```
+
+Open `http://localhost:6140`. The template is rendered with sample article
+data in a fixed 1200x630 OGP viewport and reloads automatically when the file
+changes. Relative assets are served from the template's directory.
+
 If your repository has issues and attached images, they will be exported like this tree.
 
 These output paths are configurable, so you can adapt them to your site or build pipeline.

--- a/cmd/cli/subcommand/ogimage.go
+++ b/cmd/cli/subcommand/ogimage.go
@@ -37,7 +37,10 @@ Examples:
   github-issue-cms ogimage -f content/posts/2024-01-15_103000.md
 
   # Use a custom template
-  github-issue-cms ogimage -f article.md -t custom-ogp.html`,
+  github-issue-cms ogimage -f article.md -t custom-ogp.html
+
+  # Preview a template while editing it
+  github-issue-cms ogimage preview ogp.html`,
 
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runOGCImage(cmd, markdownFile, templateFile)
@@ -47,6 +50,7 @@ Examples:
 	cmd.Flags().StringVarP(&markdownFile, "file", "f", "", "Path to the markdown file (required)")
 	cmd.Flags().StringVarP(&templateFile, "template", "t", "", "Path to a custom OGP HTML template (optional)")
 	_ = cmd.MarkFlagRequired("file")
+	cmd.AddCommand(NewOGImagePreviewCommand())
 
 	return cmd
 }

--- a/cmd/cli/subcommand/ogimage_preview.go
+++ b/cmd/cli/subcommand/ogimage_preview.go
@@ -1,0 +1,297 @@
+package subcommand
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"html"
+	"html/template"
+	"io"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/rokuosan/github-issue-cms/pkg/ogimage"
+	"github.com/spf13/cobra"
+)
+
+// NewOGImagePreviewCommand creates the template preview subcommand.
+func NewOGImagePreviewCommand() *cobra.Command {
+	var (
+		host string
+		port int
+	)
+
+	cmd := &cobra.Command{
+		Use:   "preview <template>",
+		Short: "Preview an OGP HTML template in a fixed 1200x630 viewport",
+		Long: `Start a local live preview server for an OGP HTML template.
+
+The template is rendered with sample OGP data and displayed at the fixed
+1200x630 OGP size. The preview reloads automatically when the template file
+changes. Files referenced with relative URLs are served from the template's
+directory.
+
+Example:
+  github-issue-cms ogimage preview ogp.html`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runOGImagePreview(cmd.Context(), cmd.OutOrStdout(), args[0], host, port)
+		},
+	}
+
+	cmd.Flags().StringVar(&host, "host", "localhost", "Host to bind the preview server to")
+	cmd.Flags().IntVarP(&port, "port", "p", 6140, "Port to bind the preview server to")
+
+	return cmd
+}
+
+func runOGImagePreview(ctx context.Context, output io.Writer, templatePath, host string, port int) error {
+	if port < 0 || port > 65535 {
+		return fmt.Errorf("invalid port %d: must be between 0 and 65535", port)
+	}
+
+	absTemplatePath, err := filepath.Abs(templatePath)
+	if err != nil {
+		return fmt.Errorf("resolve template path: %w", err)
+	}
+	info, err := os.Stat(absTemplatePath)
+	if err != nil {
+		return fmt.Errorf("stat template %s: %w", templatePath, err)
+	}
+	if info.IsDir() {
+		return fmt.Errorf("template path is a directory: %s", templatePath)
+	}
+
+	listener, err := net.Listen("tcp", net.JoinHostPort(host, strconv.Itoa(port)))
+	if err != nil {
+		return fmt.Errorf("listen for preview server: %w", err)
+	}
+
+	server := &http.Server{
+		Handler:           newOGImagePreviewHandler(absTemplatePath),
+		ReadHeaderTimeout: 5 * time.Second,
+	}
+	serverErrors := make(chan error, 1)
+	go func() {
+		serverErrors <- server.Serve(listener)
+	}()
+
+	actualPort := listener.Addr().(*net.TCPAddr).Port
+	displayHost := host
+	if displayHost == "" {
+		displayHost = "localhost"
+	}
+	address := net.JoinHostPort(displayHost, strconv.Itoa(actualPort))
+	if _, err := fmt.Fprintf(output, "OGP preview server: http://%s\n", address); err != nil {
+		_ = server.Close()
+		return fmt.Errorf("write preview server address: %w", err)
+	}
+
+	select {
+	case <-ctx.Done():
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		if err := server.Shutdown(shutdownCtx); err != nil {
+			return fmt.Errorf("shutdown preview server: %w", err)
+		}
+		return ctx.Err()
+	case err := <-serverErrors:
+		if err == http.ErrServerClosed {
+			return nil
+		}
+		return fmt.Errorf("preview server: %w", err)
+	}
+}
+
+type ogImagePreviewHandler struct {
+	templatePath string
+	templateDir  string
+}
+
+func newOGImagePreviewHandler(templatePath string) http.Handler {
+	return &ogImagePreviewHandler{
+		templatePath: templatePath,
+		templateDir:  filepath.Dir(templatePath),
+	}
+}
+
+func (h *ogImagePreviewHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	switch {
+	case r.URL.Path == "/":
+		h.serveShell(w)
+	case r.URL.Path == "/__preview":
+		h.serveTemplate(w)
+	case r.URL.Path == "/__preview/version":
+		h.serveVersion(w)
+	case strings.HasPrefix(r.URL.Path, "/__asset/"):
+		h.serveAsset(w, r)
+	default:
+		http.NotFound(w, r)
+	}
+}
+
+func (h *ogImagePreviewHandler) serveShell(w http.ResponseWriter) {
+	name := html.EscapeString(filepath.Base(h.templatePath))
+	shell := fmt.Sprintf(previewShell, name, name)
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	_, _ = w.Write([]byte(shell))
+}
+
+func (h *ogImagePreviewHandler) serveTemplate(w http.ResponseWriter) {
+	tmpl, err := template.ParseFiles(h.templatePath)
+	if err != nil {
+		h.serveTemplateError(w, fmt.Errorf("parse template: %w", err))
+		return
+	}
+
+	var rendered bytes.Buffer
+	if err := tmpl.Execute(&rendered, previewOGPData()); err != nil {
+		h.serveTemplateError(w, fmt.Errorf("execute template: %w", err))
+		return
+	}
+
+	w.Header().Set("Cache-Control", "no-store")
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	_, _ = w.Write([]byte(injectAssetBase(rendered.String())))
+}
+
+func (h *ogImagePreviewHandler) serveTemplateError(w http.ResponseWriter, err error) {
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	w.WriteHeader(http.StatusUnprocessableEntity)
+	message := html.EscapeString(err.Error())
+	_, _ = fmt.Fprintf(w, `<!doctype html><meta charset="utf-8"><style>body{margin:0;padding:32px;background:#1f1f1f;color:#ffb4ab;font:16px/1.5 ui-monospace,SFMono-Regular,Menlo,monospace;white-space:pre-wrap}</style>%s`, message)
+}
+
+func (h *ogImagePreviewHandler) serveVersion(w http.ResponseWriter) {
+	info, err := os.Stat(h.templatePath)
+	version := "missing"
+	if err == nil {
+		version = fmt.Sprintf("%d-%d", info.ModTime().UnixNano(), info.Size())
+	}
+	w.Header().Set("Cache-Control", "no-store")
+	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+	_, _ = w.Write([]byte(version))
+}
+
+func (h *ogImagePreviewHandler) serveAsset(w http.ResponseWriter, r *http.Request) {
+	assetServer := http.StripPrefix("/__asset/", http.FileServer(http.Dir(h.templateDir)))
+	assetServer.ServeHTTP(w, r)
+}
+
+func previewOGPData() ogimage.OGPData {
+	return ogimage.OGPData{
+		Title:    "OGP template preview",
+		Author:   "github-issue-cms",
+		Date:     "2026-01-01",
+		Category: "Example",
+		Tags:     []string{"preview", "ogp"},
+	}
+}
+
+func injectAssetBase(document string) string {
+	lower := strings.ToLower(document)
+	if strings.Contains(lower, "<base ") {
+		return document
+	}
+
+	if headStart := strings.Index(lower, "<head"); headStart >= 0 {
+		if headEnd := strings.Index(lower[headStart:], ">"); headEnd >= 0 {
+			insertAt := headStart + headEnd + 1
+			return document[:insertAt] + "\n<base href=\"/__asset/\">" + document[insertAt:]
+		}
+	}
+	return `<base href="/__asset/">` + document
+}
+
+const previewShell = `<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>OGP preview: %s</title>
+<style>
+  :root { color-scheme: dark; }
+  * { box-sizing: border-box; }
+  html, body { min-height: 100%%; }
+  body {
+    margin: 0;
+    min-width: 320px;
+    background: #202124;
+    color: #e8eaed;
+    font: 14px/1.4 -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  }
+  header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 16px;
+    min-height: 52px;
+    padding: 12px 20px;
+    border-bottom: 1px solid #3c4043;
+  }
+  header strong { font-weight: 600; }
+  header span { color: #9aa0a6; font-size: 12px; }
+  main {
+    display: grid;
+    min-height: calc(100vh - 53px);
+    place-items: center;
+    padding: 16px;
+  }
+  .stage {
+    position: relative;
+    width: min(1200px, calc(100vw - 32px));
+    aspect-ratio: 1200 / 630;
+    overflow: hidden;
+    background: #fff;
+    box-shadow: 0 12px 40px rgb(0 0 0 / 35%%);
+  }
+  iframe {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 1200px;
+    height: 630px;
+    border: 0;
+    transform-origin: top left;
+  }
+</style>
+</head>
+<body>
+<header><strong>OGP preview</strong><span>%s · 1200 × 630</span></header>
+<main><div class="stage"><iframe id="preview" title="OGP template preview"></iframe></div></main>
+<script>
+const frame = document.getElementById('preview');
+const stage = document.querySelector('.stage');
+let version = '';
+
+function resizePreview() {
+  frame.style.transform = 'scale(' + (stage.clientWidth / 1200) + ')';
+}
+
+function reloadPreview(nextVersion) {
+  version = nextVersion;
+  frame.src = '/__preview?version=' + encodeURIComponent(nextVersion);
+}
+
+async function checkForChanges() {
+  try {
+    const response = await fetch('/__preview/version', { cache: 'no-store' });
+    const nextVersion = await response.text();
+    if (nextVersion !== version) reloadPreview(nextVersion);
+  } catch (_) {
+    // The server may be restarting while the file is being edited.
+  }
+}
+
+window.addEventListener('resize', resizePreview);
+resizePreview();
+checkForChanges();
+setInterval(checkForChanges, 500);
+</script>
+</body>
+</html>`

--- a/cmd/cli/subcommand/ogimage_preview_test.go
+++ b/cmd/cli/subcommand/ogimage_preview_test.go
@@ -1,0 +1,90 @@
+package subcommand
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewOGImagePreviewCommand(t *testing.T) {
+	cmd := NewOGImagePreviewCommand()
+
+	assert.Equal(t, "preview <template>", cmd.Use)
+	assert.Contains(t, cmd.Short, "1200x630")
+	assert.Equal(t, "localhost", cmd.Flag("host").DefValue)
+	assert.Equal(t, "6140", cmd.Flag("port").DefValue)
+}
+
+func TestOGImagePreviewHandler_RendersTemplateAndAssets(t *testing.T) {
+	dir := t.TempDir()
+	templatePath := filepath.Join(dir, "ogp.html")
+	require.NoError(t, os.WriteFile(templatePath, []byte(`<!doctype html><html><head></head><body><h1>{{ .Title }}</h1><img src="logo.svg"></body></html>`), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "logo.svg"), []byte("<svg></svg>"), 0o644))
+
+	server := httptest.NewServer(newOGImagePreviewHandler(templatePath))
+	t.Cleanup(server.Close)
+
+	response, err := http.Get(server.URL + "/__preview")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = response.Body.Close() })
+	assert.Equal(t, http.StatusOK, response.StatusCode)
+
+	body := readResponseBody(t, response)
+	assert.Contains(t, body, "OGP template preview")
+	assert.Contains(t, body, `<base href="/__asset/">`)
+	assert.NotContains(t, body, `\\n<base`)
+
+	assetResponse, err := http.Get(server.URL + "/__asset/logo.svg")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = assetResponse.Body.Close() })
+	assert.Equal(t, http.StatusOK, assetResponse.StatusCode)
+	assert.Equal(t, "<svg></svg>", readResponseBody(t, assetResponse))
+}
+
+func TestOGImagePreviewHandler_ShowsTemplateErrors(t *testing.T) {
+	templatePath := filepath.Join(t.TempDir(), "ogp.html")
+	require.NoError(t, os.WriteFile(templatePath, []byte(`{{ if }}`), 0o644))
+
+	request := httptest.NewRequest(http.MethodGet, "/__preview", nil)
+	recorder := httptest.NewRecorder()
+	newOGImagePreviewHandler(templatePath).ServeHTTP(recorder, request)
+
+	assert.Equal(t, http.StatusUnprocessableEntity, recorder.Code)
+	assert.Contains(t, recorder.Body.String(), "parse template")
+	assert.Equal(t, "text/html; charset=utf-8", recorder.Header().Get("Content-Type"))
+}
+
+func TestOGImagePreviewHandler_Version(t *testing.T) {
+	templatePath := filepath.Join(t.TempDir(), "ogp.html")
+	require.NoError(t, os.WriteFile(templatePath, []byte("template"), 0o644))
+
+	handler := newOGImagePreviewHandler(templatePath)
+	first := httptest.NewRecorder()
+	handler.ServeHTTP(first, httptest.NewRequest(http.MethodGet, "/__preview/version", nil))
+
+	require.NoError(t, os.WriteFile(templatePath, []byte("updated template"), 0o644))
+	second := httptest.NewRecorder()
+	handler.ServeHTTP(second, httptest.NewRequest(http.MethodGet, "/__preview/version", nil))
+
+	assert.NotEmpty(t, first.Body.String())
+	assert.NotEqual(t, first.Body.String(), second.Body.String())
+}
+
+func TestInjectAssetBase_DoesNotOverrideExistingBase(t *testing.T) {
+	document := `<html><head><base href="https://example.com/"></head></html>`
+
+	assert.Equal(t, document, injectAssetBase(document))
+}
+
+func readResponseBody(t *testing.T, response *http.Response) string {
+	t.Helper()
+	body, err := io.ReadAll(response.Body)
+	require.NoError(t, err)
+	return string(body)
+}

--- a/cmd/cli/subcommand/ogimage_test.go
+++ b/cmd/cli/subcommand/ogimage_test.go
@@ -44,6 +44,9 @@ func TestNewOGCImageCommand(t *testing.T) {
 	tmplFlag := cmd.Flags().Lookup("template")
 	assert.NotNil(t, tmplFlag)
 	assert.Equal(t, "t", tmplFlag.Shorthand)
+
+	assert.NotNil(t, cmd.Commands())
+	assert.Equal(t, "preview <template>", cmd.Commands()[0].Use)
 }
 
 func TestOGCImageCommand_MissingFile(t *testing.T) {


### PR DESCRIPTION
## Summary
- add `ogimage preview <template>` with a local live preview server
- render templates in a fixed 1200x630 OGP viewport with automatic reloads
- serve relative assets and show template errors without stopping the server
- document the workflow and add HTTP handler tests

## Verification
- `go test ./...`
- `go vet ./...`
- `golangci-lint run`
- `go test -race ./cmd/cli/subcommand`